### PR TITLE
Improve drop zone accessibility

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -49,6 +49,12 @@
   cursor: pointer;
 }
 
+.drop-zone:focus-visible {
+  outline: 3px solid #1d4ed8;
+  outline-offset: 4px;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.25);
+}
+
 .drop-zone.active {
   border-color: #2563eb;
   background: #eff6ff;

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -116,6 +116,16 @@ function App() {
     fileInputRef.current?.click()
   }, [])
 
+  const onDropZoneKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        onBrowseClick()
+      }
+    },
+    [onBrowseClick],
+  )
+
   return (
     <div className="app">
       <header className="header">
@@ -131,6 +141,9 @@ function App() {
         onDrop={onDrop}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
+        onKeyDown={onDropZoneKeyDown}
+        role="button"
+        tabIndex={0}
       >
         <input
           ref={fileInputRef}


### PR DESCRIPTION
## Summary
- make the drag-and-drop zone keyboard accessible by adding button semantics and handling Enter/Space
- mirror browse click behavior on key activation and retain existing interactions
- add a focus-visible outline and shadow that meets contrast guidelines for the drop zone

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb530c71d88328b4a9e1ce7981af1b