### PR TITLE
feat: add configurable file size limit

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -92,6 +92,39 @@
   transform: translateY(-1px);
 }
 
+.settings {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
+.settings__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #f8fafc;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+}
+
+.settings__item input {
+  width: 5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.settings__item input:disabled {
+  background: #e2e8f0;
+  cursor: not-allowed;
+}
+
 .error {
   padding: 1rem 1.25rem;
   border-radius: 0.75rem;

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -36,6 +36,15 @@ function formatHex(
   return lines.join('\n')
 }
 
+const BYTES_PER_MEGABYTE = 1024 * 1024
+const DEFAULT_MAX_FILE_SIZE_MB = 25
+const MIN_FILE_SIZE_MB = 1
+const MAX_FILE_SIZE_MB = 500
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
 function App() {
   const [status, setStatus] = useState('Drop a packet capture or binary payload to analyze.')
   const [packetSummary, setPacketSummary] = useState('Awaiting packet data.')
@@ -43,6 +52,7 @@ function App() {
   const [dragActive, setDragActive] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isReady, setIsReady] = useState(false)
+  const [maxFileSizeMB, setMaxFileSizeMB] = useState(DEFAULT_MAX_FILE_SIZE_MB)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
@@ -59,7 +69,19 @@ function App() {
   }, [])
 
   const handleFile = useCallback(async (file: File) => {
+    const maxBytes = maxFileSizeMB * BYTES_PER_MEGABYTE
+    if (file.size > maxBytes) {
+      const fileSizeMB = file.size / BYTES_PER_MEGABYTE
+      const formattedFileSize = fileSizeMB.toFixed(fileSizeMB >= 10 ? 0 : 2)
+      setError(
+        `${file.name} is ${formattedFileSize} MB, which exceeds the configured limit of ${maxFileSizeMB} MB.`,
+      )
+      setStatus('Choose a smaller file or increase the max file size limit.')
+      return
+    }
+
     setStatus(`Processing ${file.name} (${file.size} bytes)…`)
+    setError(null)
 
     try {
       const buffer = await file.arrayBuffer()
@@ -76,7 +98,7 @@ function App() {
       setError('Failed to process the uploaded file.')
       setStatus('Drop a packet capture or binary payload to analyze.')
     }
-  }, [])
+  }, [maxFileSizeMB])
 
   const onDrop = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
@@ -116,6 +138,16 @@ function App() {
     fileInputRef.current?.click()
   }, [])
 
+  const onMaxFileSizeChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const parsedValue = Number(event.target.value)
+    if (Number.isNaN(parsedValue)) {
+      return
+    }
+
+    const clampedValue = clamp(parsedValue, MIN_FILE_SIZE_MB, MAX_FILE_SIZE_MB)
+    setMaxFileSizeMB(clampedValue)
+  }, [])
+
   return (
     <div className="app">
       <header className="header">
@@ -145,6 +177,22 @@ function App() {
         <button className="browse-button" type="button" onClick={onBrowseClick} disabled={!isReady}>
           Browse files
         </button>
+      </section>
+
+      <section className="settings">
+        <label className="settings__item" htmlFor="max-file-size">
+          <span>Max file size (MB)</span>
+          <input
+            id="max-file-size"
+            type="number"
+            min={MIN_FILE_SIZE_MB}
+            max={MAX_FILE_SIZE_MB}
+            step={1}
+            value={maxFileSizeMB}
+            onChange={onMaxFileSizeChange}
+            disabled={!isReady}
+          />
+        </label>
       </section>
 
       {error && <div className="error">{error}</div>}


### PR DESCRIPTION
## Summary
- add configurable file size limit to prevent loading extremely large payloads
- surface validation errors and guidance when the configured limit is exceeded
- expose a UI control for tuning the max file size limit and style it to match the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb5308ce3083289406c6d886016671