### PR TITLE
Use base-aware URLs for WASM loader

### DIFF
--- a/webapp/src/wasm.ts
+++ b/webapp/src/wasm.ts
@@ -4,8 +4,8 @@ export type PacketProcessor = {
 
 let cachedProcessor: PacketProcessor | null = null
 
-const wasmPath = '/pkg/core_bg.wasm'
-const wasmModule = '/pkg/core.js'
+const wasmPath = new URL('pkg/core_bg.wasm', import.meta.env.BASE_URL)
+const wasmModule = new URL('pkg/core.js', import.meta.env.BASE_URL)
 
 type InitFn = (
   input?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module,
@@ -16,12 +16,12 @@ export async function loadProcessor(): Promise<PacketProcessor> {
     return cachedProcessor
   }
 
-  const module = (await import(/* @vite-ignore */ wasmModule)) as {
+  const module = (await import(/* @vite-ignore */ wasmModule.href)) as {
     default: InitFn
     process_packet: (data: Uint8Array) => string
   }
 
-  await module.default(wasmPath)
+  await module.default(wasmPath.href)
   cachedProcessor = { process_packet: module.process_packet }
   return cachedProcessor
 }


### PR DESCRIPTION
## Summary
- build the core wasm and js asset URLs with import.meta.env.BASE_URL so hosted paths are respected
- pass the resolved URLs into the dynamic import and wasm initializer

## Testing
- npm run lint
- npm run dev -- --base=/foo/ --host=127.0.0.1 --port=4173 --clearScreen=false
- npm run build -- --base=/foo/
- npm run preview -- --host=127.0.0.1 --port=4173

------
https://chatgpt.com/codex/tasks/task_e_68cb5307148083288e75451c5509566e