### PR TITLE
Reset panes on failed uploads

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -92,6 +92,8 @@ function App() {
           `${file.name} is ${formattedFileSize} MB, which exceeds the configured limit of ${maxFileSizeMB} MB.`,
         );
         setStatus("Choose a smaller file or increase the max file size limit.");
+        setPacketSummary("Awaiting packet data.");
+        setHexDump("No data loaded.");
         return;
       }
 
@@ -112,6 +114,8 @@ function App() {
         console.error("Processing failed", err);
         setError("Failed to process the uploaded file.");
         setStatus("Drop a packet capture or binary payload to analyze.");
+        setPacketSummary("Awaiting packet data.");
+        setHexDump("No data loaded.");
       }
     },
     [maxFileSizeMB],


### PR DESCRIPTION
## Summary
- restore the packet summary and hex dump placeholders when oversized files are rejected
- reset both panes after processing failures so the UI reflects the error state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb5852e93c8328bd54c197b1306100