### PR TITLE
Handle multiple files sequentially

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -59,7 +59,7 @@ function clamp(value: number, min: number, max: number) {
 
 function App() {
   const [status, setStatus] = useState(
-    "Drop a packet capture or binary payload to analyze.",
+    "Drop packet captures or binary payloads to analyze.",
   );
   const [packetSummary, setPacketSummary] = useState("Awaiting packet data.");
   const [hexDump, setHexDump] = useState("No data loaded.");
@@ -68,12 +68,13 @@ function App() {
   const [isReady, setIsReady] = useState(false);
   const [maxFileSizeMB, setMaxFileSizeMB] = useState(DEFAULT_MAX_FILE_SIZE_MB);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const processingQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
     loadProcessor()
       .then(() => {
         setIsReady(true);
-        setStatus("Drop a packet capture or binary payload to analyze.");
+        setStatus("Drop packet captures or binary payloads to analyze.");
       })
       .catch((err) => {
         console.error("Failed to load Wasm module", err);
@@ -111,22 +112,34 @@ function App() {
       } catch (err) {
         console.error("Processing failed", err);
         setError("Failed to process the uploaded file.");
-        setStatus("Drop a packet capture or binary payload to analyze.");
+        setStatus("Drop packet captures or binary payloads to analyze.");
       }
     },
     [maxFileSizeMB],
   );
 
-  const onDrop = useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      setDragActive(false);
-      const file = event.dataTransfer.files?.[0];
-      if (file) {
-        void handleFile(file);
-      }
+  const enqueueFile = useCallback(
+    (file: File) => {
+      processingQueueRef.current = processingQueueRef.current
+        .then(() => handleFile(file))
+        .catch((err) => {
+          console.error("Queued file processing failed", err);
+        });
+      return processingQueueRef.current;
     },
     [handleFile],
+  );
+
+  const onDrop = useCallback(
+    async (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setDragActive(false);
+      const files = Array.from(event.dataTransfer.files ?? []);
+      for (const file of files) {
+        await enqueueFile(file);
+      }
+    },
+    [enqueueFile],
   );
 
   const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
@@ -141,14 +154,15 @@ function App() {
   }, []);
 
   const onFileChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (file) {
-        void handleFile(file);
-        event.target.value = "";
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const input = event.target;
+      const files = Array.from(input.files ?? []);
+      for (const file of files) {
+        await enqueueFile(file);
       }
+      input.value = "";
     },
-    [handleFile],
+    [enqueueFile],
   );
 
   const onBrowseClick = useCallback(() => {


### PR DESCRIPTION
## Summary
- queue file processing so files are handled sequentially
- iterate through dropped or selected files instead of only the first entry
- update status copy to reflect multi-file support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb585cbe2c8328b6a12560dee9c8f1