### PR TITLE
Add GitHub Pages deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: webapp/package-lock.json
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build WebAssembly package
+        run: wasm-pack build core --target web --out-dir webapp/public/pkg
+
+      - name: Install frontend dependencies
+        working-directory: webapp
+        run: npm ci
+
+      - name: Build site
+        working-directory: webapp
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: webapp/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ npm run build
 - The React UI preloads `core.wasm`, handles drag-and-drop uploads, and renders placeholder panes for packet summaries and hex
   output to make iterating on the Wasm module straightforward.
 - Additional tooling (tests, linting, CI) will be added as the project grows.
+
+---
+
+## GitHub Pages Deployment
+
+- Pushes to the `main` branch automatically build the WebAssembly core, bundle the React
+  frontend, and publish the static site to GitHub Pages via the workflow defined in
+  [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).
+- The Vite configuration detects the repository name from the GitHub Actions environment
+  and adjusts the base path so assets resolve correctly when served from
+  `https://<username>.github.io/<repository>/`.
+- To trigger a manual deployment, run the **Deploy GitHub Pages** workflow from the
+  Actions tab in the GitHub UI.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,3 +8,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.5.2",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1402,6 +1403,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.13",
@@ -3192,6 +3203,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.5.2",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/webapp/src/wasm.ts
+++ b/webapp/src/wasm.ts
@@ -5,8 +5,8 @@ export type PacketProcessor = {
 let cachedProcessor: PacketProcessor | null = null;
 let loadPromise: Promise<PacketProcessor> | null = null;
 
-const wasmPath = new URL("pkg/core_bg.wasm", import.meta.env.BASE_URL);
-const wasmModule = new URL("pkg/core.js", import.meta.env.BASE_URL);
+const wasmPath = new URL("pkg/core_bg.wasm", import.meta.env.BASE_URL).toString();
+const wasmModule = new URL("pkg/core.js", import.meta.env.BASE_URL).toString();
 
 type InitFn = (
   input?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module,

--- a/webapp/tsconfig.node.json
+++ b/webapp/tsconfig.node.json
@@ -12,6 +12,7 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
 
     /* Linting */
     "strict": true,

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const repository = process.env.GITHUB_REPOSITORY;
+const repositoryName = repository?.includes("/")
+  ? repository.split("/")[1]
+  : undefined;
+
 // https://vite.dev/config/
 export default defineConfig({
+  base: repositoryName ? `/${repositoryName}/` : "/",
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the WebAssembly core, bundles the React frontend, and deploys the site to GitHub Pages
- configure the Vite build to detect the repository base path and document the new deployment pipeline
- update tooling to support TypeScript node types and skip wasm-opt so the workflow runs reliably

## Testing
- wasm-pack build core --target web --out-dir webapp/public/pkg
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb588db43483289cd8dfc461e29c6f