### PR TITLE
ci: auto commit pre-commit fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,18 @@ jobs:
         run: pip install pre-commit
 
       - name: Run pre-commit
+        id: precommit
+        continue-on-error: true
+        run: pre-commit run --all-files
+
+      - name: Commit pre-commit changes
+        if: steps.precommit.outcome == 'failure' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: apply pre-commit fixes"
+
+      - name: Rerun pre-commit
+        if: steps.precommit.outcome == 'failure'
         run: pre-commit run --all-files
 
   rust:


### PR DESCRIPTION
## Summary
- rerun the pre-commit job with continue-on-error to detect auto-fixable changes
- automatically commit pre-commit fixes on push branches and rerun the hooks

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cb5d7113a88328a9d845089f8af99d