### PR TITLE
Add display filter support to packet list

### DIFF
--- a/docs/src/App.css
+++ b/docs/src/App.css
@@ -208,6 +208,35 @@
   min-width: min(320px, 100%);
 }
 
+.filter-input input[aria-invalid="true"] {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.35);
+}
+
+.filter-right {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.filter-meta {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  min-height: 1.25rem;
+  display: flex;
+  align-items: center;
+}
+
+.filter-count {
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.filter-error {
+  color: #fca5a5;
+  font-weight: 500;
+}
+
 .filter-input input:disabled {
   opacity: 0.7;
 }


### PR DESCRIPTION
## Summary
- implement a lightweight boolean parser/evaluator to power Wireshark-style display filters
- connect the display filter input to packet list/detail panes with filtering, empty-state messaging, and counts
- style the filter bar to surface validation errors and live match statistics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb5f4a70dc83289d9b16e54b70ee74