### PR TITLE
Prevent docs App state updates after unmount

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -311,15 +311,30 @@ function App() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const processingQueueRef = useRef<Promise<void>>(Promise.resolve());
   const uploadTokenRef = useRef(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      uploadTokenRef.current += 1;
+    };
+  }, []);
 
   useEffect(() => {
     loadProcessor()
       .then(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
         setIsReady(true);
         setStatus("Drop packet captures or binary payloads to analyze.");
       })
       .catch((err) => {
         console.error("Failed to load Wasm module", err);
+        if (!isMountedRef.current) {
+          return;
+        }
         setError("Unable to load the WebAssembly packet processor.");
         setStatus("Reload the page or check the Wasm build output.");
       });
@@ -332,16 +347,34 @@ function App() {
       if (file.size > maxBytes) {
         const fileSizeMB = file.size / BYTES_PER_MEGABYTE;
         const formattedFileSize = fileSizeMB.toFixed(fileSizeMB >= 10 ? 0 : 2);
+        if (!isMountedRef.current) {
+          return;
+        }
         setError(
           `${file.name} is ${formattedFileSize} MB, which exceeds the configured limit of ${maxFileSizeMB} MB.`,
         );
+        if (!isMountedRef.current) {
+          return;
+        }
         setStatus("Choose a smaller file or increase the max file size limit.");
+        if (!isMountedRef.current) {
+          return;
+        }
         setPacketSummary("Awaiting packet data.");
+        if (!isMountedRef.current) {
+          return;
+        }
         setHexDump("No data loaded.");
         return;
       }
 
+      if (!isMountedRef.current) {
+        return;
+      }
       setStatus(`Processing ${file.name} (${file.size} bytes)…`);
+      if (!isMountedRef.current) {
+        return;
+      }
       setError(null);
 
       try {
@@ -359,19 +392,43 @@ function App() {
         if (uploadTokenRef.current !== token) {
           return;
         }
+        if (!isMountedRef.current) {
+          return;
+        }
         setPacketSummary(summary);
+        if (!isMountedRef.current) {
+          return;
+        }
         setHexDump(formatHex(bytes));
+        if (!isMountedRef.current) {
+          return;
+        }
         setStatus(`Processed ${file.name}.`);
+        if (!isMountedRef.current) {
+          return;
+        }
         setError(null);
       } catch (err) {
         console.error("Processing failed", err);
         if (uploadTokenRef.current !== token) {
           return;
         }
+        if (!isMountedRef.current) {
+          return;
+        }
         setError("Failed to process the uploaded file.");
 
+        if (!isMountedRef.current) {
+          return;
+        }
         setStatus("Drop a packet capture or binary payload to analyze.");
+        if (!isMountedRef.current) {
+          return;
+        }
         setPacketSummary("Awaiting packet data.");
+        if (!isMountedRef.current) {
+          return;
+        }
         setHexDump("No data loaded.");
       }
     },


### PR DESCRIPTION
## Summary
- add an isMountedRef to the docs app that invalidates pending uploads on unmount
- guard all handleFile state updates so they short-circuit when the component is unmounted

## Testing
- npm run dev -- --host

------
https://chatgpt.com/codex/tasks/task_e_68cc335c2a648328a64fc98701748b65