### PR TITLE
Update Prettier to format docs frontend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,5 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        files: ^webapp/
-        exclude: ^webapp/node_modules/
+        files: ^docs/
+        exclude: ^docs/node_modules/

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -170,7 +170,11 @@ function parseFilter(tokens: FilterToken[]): FilterNode {
         break;
       }
 
-      if (next.type === "TEXT" || next.type === "LPAREN" || next.type === "NOT") {
+      if (
+        next.type === "TEXT" ||
+        next.type === "LPAREN" ||
+        next.type === "NOT"
+      ) {
         const right = parseNot();
         node = { type: "and", left: node, right };
         continue;
@@ -230,9 +234,13 @@ function evaluateFilter(node: FilterNode, line: string): boolean {
     case "text":
       return line.includes(node.value);
     case "and":
-      return evaluateFilter(node.left, line) && evaluateFilter(node.right, line);
+      return (
+        evaluateFilter(node.left, line) && evaluateFilter(node.right, line)
+      );
     case "or":
-      return evaluateFilter(node.left, line) || evaluateFilter(node.right, line);
+      return (
+        evaluateFilter(node.left, line) || evaluateFilter(node.right, line)
+      );
     case "not":
       return !evaluateFilter(node.operand, line);
     default:
@@ -661,7 +669,9 @@ function App() {
               value={filterText}
               onChange={onFilterChange}
               aria-invalid={filterError ? true : false}
-              aria-describedby={filterError ? "display-filter-error" : undefined}
+              aria-describedby={
+                filterError ? "display-filter-error" : undefined
+              }
             />
           </label>
           <div className="filter-right">

--- a/docs/src/wasm.ts
+++ b/docs/src/wasm.ts
@@ -7,15 +7,16 @@ let loadPromise: Promise<PacketProcessor> | null = null;
 
 const baseUrl = import.meta.env.BASE_URL ?? "/";
 
-
 const resolveOrigin = (): string => {
   if (typeof window !== "undefined" && window.location) {
     return window.location.origin;
   }
 
-  const nodeProcess = (globalThis as {
-    process?: { env?: Record<string, string | undefined> };
-  }).process;
+  const nodeProcess = (
+    globalThis as {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process;
 
   return nodeProcess?.env?.DOCS_ORIGIN ?? "http://localhost";
 };
@@ -23,7 +24,6 @@ const resolveOrigin = (): string => {
 const absoluteBaseUrl = new URL(baseUrl, resolveOrigin());
 
 export const resolveAssetUrl = (path: string): URL => {
-
   const resolved = new URL(path, absoluteBaseUrl);
 
   if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
- retarget the Prettier pre-commit hook to the docs frontend directory
- format the docs frontend TypeScript sources with the updated hook

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cc6379b08c8328aca30003ea2e2b67