### PR TITLE
Allow selecting multiple files via browse input

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -591,6 +591,7 @@ function App() {
         id="file-input"
         type="file"
         accept=".pcap,.pcapng,.bin,.dat,.raw,.txt,application/octet-stream"
+        multiple
         onChange={onFileChange}
         hidden
       />


### PR DESCRIPTION
## Summary
- allow the hidden browse input to accept multiple files so the queue behavior matches drag-and-drop

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68cc637bb85c832898292fdee637549f