### PR TITLE
feat: add field-aware packet filtering

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -77,9 +77,7 @@ function toOptionalString(value: unknown): string | undefined {
   return undefined;
 }
 
-function toOptionalNumericLike(
-  value: unknown,
-): string | number | undefined {
+function toOptionalNumericLike(value: unknown): string | number | undefined {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -505,10 +503,12 @@ function App() {
     summaryLines.length === 1 && summaryLines[0] === "Awaiting packet data.";
   const baseSummaryEntries = useMemo(() => {
     const baseSummaryLines = awaitingPlaceholder ? [] : summaryLines;
-    return baseSummaryLines.map((line, index): PacketSummaryEntry => ({
-      record: parsePacketSummaryLine(line),
-      originalIndex: index,
-    }));
+    return baseSummaryLines.map(
+      (line, index): PacketSummaryEntry => ({
+        record: parsePacketSummaryLine(line),
+        originalIndex: index,
+      }),
+    );
   }, [awaitingPlaceholder, summaryLines]);
   const totalPackets = baseSummaryEntries.length;
   const activeFilter =

--- a/docs/src/filter.test.ts
+++ b/docs/src/filter.test.ts
@@ -17,9 +17,7 @@ const makePacket = (overrides: Partial<PacketRecord>): PacketRecord => {
 describe("filter helpers", () => {
   it("parses and evaluates explicit AND expressions", () => {
     const ast = parseFilter(tokenizeFilter("foo && bar"));
-    expect(evaluateFilter(ast, makePacket({ info: "foo and bar" }))).toBe(
-      true,
-    );
+    expect(evaluateFilter(ast, makePacket({ info: "foo and bar" }))).toBe(true);
     expect(evaluateFilter(ast, makePacket({ info: "foo only" }))).toBe(false);
     expect(evaluateFilter(ast, makePacket({ info: "bar only" }))).toBe(false);
   });
@@ -38,9 +36,7 @@ describe("filter helpers", () => {
 
   it("supports quoted phrases", () => {
     const ast = parseFilter(tokenizeFilter('"foo bar" baz'));
-    expect(evaluateFilter(ast, makePacket({ info: "foo bar baz" }))).toBe(
-      true,
-    );
+    expect(evaluateFilter(ast, makePacket({ info: "foo bar baz" }))).toBe(true);
     expect(evaluateFilter(ast, makePacket({ info: "foo qux baz" }))).toBe(
       false,
     );
@@ -84,7 +80,9 @@ describe("filter helpers", () => {
 
   it("supports negations and boolean combinations with comparisons", () => {
     const ast = parseFilter(
-      tokenizeFilter('!(protocol == "udp") && (dst contains 8.8 || info contains handshake)'),
+      tokenizeFilter(
+        '!(protocol == "udp") && (dst contains 8.8 || info contains handshake)',
+      ),
     );
     const packet = makePacket({
       info: "TLS handshake to 8.8.8.8",
@@ -102,7 +100,7 @@ describe("filter helpers", () => {
   });
 
   it("falls back to searching the Info column when a field is missing", () => {
-    const ast = parseFilter(tokenizeFilter('dst contains example || request'));
+    const ast = parseFilter(tokenizeFilter("dst contains example || request"));
     const packet = makePacket({ info: "HTTP request to example.com" });
     expect(evaluateFilter(ast, packet)).toBe(true);
 

--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -302,7 +302,10 @@ function resolveFieldValue(
   return undefined;
 }
 
-export function evaluateFilter(node: FilterNode, packet: PacketRecord): boolean {
+export function evaluateFilter(
+  node: FilterNode,
+  packet: PacketRecord,
+): boolean {
   switch (node.type) {
     case "text":
       return packet.info.toLowerCase().includes(node.value);


### PR DESCRIPTION
## Summary
- extend the filter tokenizer, AST, and evaluator to support field comparisons against structured packet records
- parse packet summary lines into structured records in the app and pass them to the enhanced filter while updating the table display
- expand filter tests to cover field-aware comparisons, negations, and fallback behavior

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cd8df5fd6c832883ccd607f06d515d