### PR TITLE
Fix filter evaluation to use packet data

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -535,7 +535,7 @@ function App() {
   const visiblePacketEntries = useMemo(() => {
     if (activeFilter && filterAst) {
       return searchablePackets.filter((entry) =>
-        evaluateFilter(filterAst, entry.searchableText),
+        evaluateFilter(filterAst, entry.packet, entry.searchableText),
       );
     }
     return searchablePackets;

--- a/docs/src/filter.test.ts
+++ b/docs/src/filter.test.ts
@@ -78,6 +78,23 @@ describe("filter helpers", () => {
     expect(evaluateFilter(ast, mismatch)).toBe(false);
   });
 
+  it("matches field comparisons when searchable text omits the field value", () => {
+    const ast = parseFilter(tokenizeFilter('protocol == "tcp"'));
+    const packet = makePacket({
+      info: "Generic packet",
+      protocol: "TCP",
+    });
+
+    const searchableText = "generic packet";
+    expect(evaluateFilter(ast, packet, searchableText)).toBe(true);
+
+    const mismatch = makePacket({
+      info: "Generic packet",
+      protocol: "udp",
+    });
+    expect(evaluateFilter(ast, mismatch, searchableText)).toBe(false);
+  });
+
   it("supports negations and boolean combinations with comparisons", () => {
     const ast = parseFilter(
       tokenizeFilter(

--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -305,10 +305,13 @@ function resolveFieldValue(
 export function evaluateFilter(
   node: FilterNode,
   packet: PacketRecord,
+  searchableText?: string,
 ): boolean {
   switch (node.type) {
     case "text":
-      return packet.info.toLowerCase().includes(node.value);
+      return (
+        (searchableText ?? packet.info.toLowerCase()).includes(node.value)
+      );
     case "comparison": {
       const value = resolveFieldValue(packet, node.field);
       if (value === undefined) {
@@ -326,14 +329,16 @@ export function evaluateFilter(
     }
     case "and":
       return (
-        evaluateFilter(node.left, packet) && evaluateFilter(node.right, packet)
+        evaluateFilter(node.left, packet, searchableText) &&
+        evaluateFilter(node.right, packet, searchableText)
       );
     case "or":
       return (
-        evaluateFilter(node.left, packet) || evaluateFilter(node.right, packet)
+        evaluateFilter(node.left, packet, searchableText) ||
+        evaluateFilter(node.right, packet, searchableText)
       );
     case "not":
-      return !evaluateFilter(node.operand, packet);
+      return !evaluateFilter(node.operand, packet, searchableText);
     default:
       return true;
   }


### PR DESCRIPTION
## Summary
- pass full packet records into display filter evaluation while preserving cached search text
- allow evaluateFilter to receive optional searchable text and propagate it through nested nodes
- extend filter tests to cover comparison filters when the search text omits the matched field value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef199e1c88328975fc850d6d63717