### PR TITLE
Handle numeric string packet lengths in Wasm parser

### DIFF
--- a/docs/src/wasm.test.ts
+++ b/docs/src/wasm.test.ts
@@ -23,3 +23,42 @@ describe("resolveAssetUrl", () => {
     }
   });
 });
+
+describe("loadProcessor", () => {
+  it("parses numeric string lengths from Wasm output", async () => {
+    const CORE_MODULE_PATH = "http://localhost/pkg/core.js";
+
+    vi.resetModules();
+    vi.doMock(CORE_MODULE_PATH, () => ({
+      __esModule: true,
+      default: vi.fn(async () => undefined),
+      process_packet: vi.fn(() =>
+        JSON.stringify({
+          packets: [
+            {
+              time: "0.000001",
+              source: "src",
+              destination: "dst",
+              protocol: "TCP",
+              length: "64",
+              info: "mock",
+              payload: [1, 2, 3],
+            },
+          ],
+          warnings: [],
+          errors: [],
+        }),
+      ),
+    }));
+
+    const { loadProcessor } = await import("./wasm");
+    const processor = await loadProcessor();
+    const result = processor.process_packet(new Uint8Array());
+
+    expect(result.packets).toHaveLength(1);
+    expect(result.packets[0]?.length).toBe(64);
+
+    vi.doUnmock(CORE_MODULE_PATH);
+    vi.resetModules();
+  });
+});

--- a/docs/src/wasm.ts
+++ b/docs/src/wasm.ts
@@ -69,7 +69,21 @@ const toStringOrFallback = (value: unknown, fallback: string): string => {
 };
 
 const toFiniteNumberOrFallback = (value: unknown, fallback: number): number => {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return fallback;
 };
 
 const decodePayload = (value: unknown, fallback: Uint8Array): Uint8Array => {


### PR DESCRIPTION
## Summary
- teach the packet length parser to accept numeric strings before falling back
- extend the Wasm loader unit test to cover string length handling by mocking the module

## Testing
- npm test -- --run src/wasm.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cef19f8e64832886b23d4181fe5a02