### PR TITLE
Fix packet summary entry usage in docs

### DIFF
--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -307,8 +307,18 @@ export function evaluateFilter(
   packet: PacketRecord,
 ): boolean {
   switch (node.type) {
-    case "text":
-      return packet.info.toLowerCase().includes(node.value);
+    case "text": {
+      const infoMatch = packet.info.toLowerCase().includes(node.value);
+      if (infoMatch) {
+        return true;
+      }
+
+      if (typeof packet.summary === "string") {
+        return packet.summary.toLowerCase().includes(node.value);
+      }
+
+      return false;
+    }
     case "comparison": {
       const value = resolveFieldValue(packet, node.field);
       if (value === undefined) {


### PR DESCRIPTION
## Summary
- remove the unused packet summary parsing helpers and avoid duplicate PacketRecord type imports
- wrap processed packets in PacketSummaryEntry objects that retain their original index and a filter-ready record
- allow text filter terms to match the aggregated packet summary so cross-field searches still work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef19ccde083289484d39275f71fd8