### PR TITLE
Unify packet record typing across UI and Wasm

### DIFF
--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -1,12 +1,15 @@
 export type PacketRecord = {
   time?: string;
   src?: string;
+  source?: string;
   dst?: string;
+  destination?: string;
   protocol?: string;
   length?: string | number;
   info: string;
   summary?: string;
-  [key: string]: string | number | undefined;
+  payload?: Uint8Array;
+  [key: string]: string | number | Uint8Array | undefined;
 };
 
 export type FilterNode =
@@ -295,7 +298,10 @@ function resolveFieldValue(
   const candidates = FIELD_ALIASES[field] ?? [field];
   for (const candidate of candidates) {
     const value = packet[candidate];
-    if (value !== undefined) {
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "number") {
       return value;
     }
   }

--- a/docs/src/wasm.ts
+++ b/docs/src/wasm.ts
@@ -1,4 +1,6 @@
-export interface PacketRecord {
+import type { PacketRecord as FilterPacketRecord } from "./filter";
+
+export interface PacketRecord extends FilterPacketRecord {
   time: string;
   source: string;
   destination: string;


### PR DESCRIPTION
## Summary
- extend the filter PacketRecord definition to cover payloads and shared address fields
- update the React app to rely on the unified PacketRecord typing and handle optional payload data
- make the Wasm PacketRecord interface extend the shared type so processor results match the UI expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef19af13883289921da004a402013