### PR TITLE
Fix packet info cell binding

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -853,7 +853,7 @@ function App() {
               </div>
               {hasPacketData ? (
                 hasVisiblePackets ? (
-                  visiblePacketEntries.map(({ packet, originalIndex }) => {
+                  visiblePacketEntries.map(({ packet, record, originalIndex }) => {
                     const isSelected = originalIndex === selectedPacketIndex;
                     return (
                       <div


### PR DESCRIPTION
## Summary
- destructure packet table entries to access each record's parsed info metadata

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d16664cbec83289fea5a49092c4161