### PR TITLE
Ensure free-text filters match searchable text

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -564,7 +564,7 @@ function App() {
   const visiblePacketEntries = useMemo(() => {
     if (activeFilter && filterAst) {
       return searchablePackets.filter((entry) =>
-        evaluateFilter(filterAst, entry.record),
+        evaluateFilter(filterAst, entry.record, entry.searchableText),
       );
     }
     return searchablePackets;

--- a/docs/src/filter.test.ts
+++ b/docs/src/filter.test.ts
@@ -124,4 +124,19 @@ describe("filter helpers", () => {
     const mismatch = makePacket({ info: "DNS query" });
     expect(evaluateFilter(ast, mismatch)).toBe(false);
   });
+
+  it("matches free-text terms against searchable text from other columns", () => {
+    const ast = parseFilter(tokenizeFilter("10.0.0.42"));
+    const packet = makePacket({
+      info: "TLS handshake",
+      src: "10.0.0.42",
+      dst: "8.8.8.8",
+    });
+
+    const searchableText = "tls handshake 10.0.0.42 8.8.8.8";
+    expect(evaluateFilter(ast, packet, searchableText)).toBe(true);
+
+    const mismatchText = "tls handshake 8.8.8.8";
+    expect(evaluateFilter(ast, packet, mismatchText)).toBe(false);
+  });
 });

--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -324,6 +324,10 @@ export function evaluateFilter(
         return packet.summary.toLowerCase().includes(node.value);
       }
 
+      if (typeof searchableText === "string") {
+        return searchableText.includes(node.value);
+      }
+
       return false;
     }
 


### PR DESCRIPTION
## Summary
- pass the precomputed searchable text into evaluateFilter when filtering packets
- fall back to searchable text when free-text filters do not match info or summary fields
- extend unit tests to verify free-text filters can match values from other columns

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d16664fd548328a0fc4ebe08ecb1f2