### PR TITLE
Refine packet summary parsing

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -7,6 +7,7 @@ import {
   type FilterNode,
   type PacketRecord as FilterPacketRecord,
 } from "./filter";
+import { parsePacketSummaryLine } from "./summary";
 import { loadProcessor, type PacketRecord as WasmPacketRecord } from "./wasm";
 
 const BYTE_TO_HEX = (() => {
@@ -62,141 +63,6 @@ const MAX_FILE_SIZE_MB = 500;
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
-}
-
-function toOptionalString(value: unknown): string | undefined {
-  if (value === null || value === undefined) {
-    return undefined;
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return undefined;
-}
-
-function toOptionalNumericLike(value: unknown): string | number | undefined {
-  if (value === null || value === undefined) {
-    return undefined;
-  }
-  if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "boolean") {
-    return value ? "1" : "0";
-  }
-  return undefined;
-}
-
-function parsePacketSummaryLine(line: string): FilterPacketRecord {
-  const trimmed = line.trim();
-  const record: FilterPacketRecord = { info: trimmed, summary: trimmed };
-
-  if (trimmed.length === 0) {
-    return record;
-  }
-
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return record;
-    }
-
-    const data = parsed as Record<string, unknown>;
-
-    const infoValue =
-      toOptionalString(data.info) ??
-      toOptionalString(data.Info) ??
-      toOptionalString(data.summary) ??
-      toOptionalString(data.Summary);
-    if (infoValue) {
-      record.info = infoValue;
-    }
-
-    const summaryValue =
-      toOptionalString(data.summary) ?? toOptionalString(data.Summary);
-    if (summaryValue) {
-      record.summary = summaryValue;
-    }
-
-    const timeValue =
-      toOptionalString(data.time) ??
-      toOptionalString(data.timestamp) ??
-      toOptionalString(data.Time) ??
-      toOptionalString(data.Timestamp);
-    if (timeValue) {
-      record.time = timeValue;
-    }
-
-    const srcValue =
-      toOptionalString(data.src) ??
-      toOptionalString(data.source) ??
-      toOptionalString(data.Source);
-    if (srcValue) {
-      record.src = srcValue;
-      record.source = srcValue;
-    }
-
-    const dstValue =
-      toOptionalString(data.dst) ??
-      toOptionalString(data.destination) ??
-      toOptionalString(data.Dst) ??
-      toOptionalString(data.Destination);
-    if (dstValue) {
-      record.dst = dstValue;
-      record.destination = dstValue;
-    }
-
-    const protocolValue =
-      toOptionalString(data.protocol) ??
-      toOptionalString(data.proto) ??
-      toOptionalString(data.Protocol) ??
-      toOptionalString(data.Proto);
-    if (protocolValue) {
-      record.protocol = protocolValue;
-    }
-
-    const lengthValue =
-      toOptionalNumericLike(data.length) ??
-      toOptionalNumericLike(data.len) ??
-      toOptionalNumericLike(data.size) ??
-      toOptionalNumericLike(data.Length) ??
-      toOptionalNumericLike(data.Len) ??
-      toOptionalNumericLike(data.Size);
-    if (lengthValue !== undefined) {
-      record.length = lengthValue;
-    }
-
-    for (const [key, value] of Object.entries(data)) {
-      if (value === null || value === undefined) {
-        continue;
-      }
-      if (key in record) {
-        continue;
-      }
-      if (typeof value === "string" || typeof value === "number") {
-        record[key] = value;
-        continue;
-      }
-      if (typeof value === "boolean") {
-        record[key] = value ? "true" : "false";
-      }
-    }
-
-    record.summary ??= record.info;
-    return record;
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.debug("Failed to parse packet summary line", error);
-    }
-  }
-
-  return record;
 }
 
 function toFilterPacketRecord(packet: WasmPacketRecord): FilterPacketRecord {

--- a/docs/src/summary.test.ts
+++ b/docs/src/summary.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PacketRecord as FilterPacketRecord } from "./filter";
+import { parsePacketSummaryLine } from "./summary";
+
+function baseRecord(info: string): FilterPacketRecord {
+  return { info, summary: info };
+}
+
+describe("parsePacketSummaryLine", () => {
+  it("returns plain text summaries without parsing JSON", () => {
+    const spy = vi.spyOn(JSON, "parse");
+    const text = "Simple packet description";
+
+    const result = parsePacketSummaryLine(text);
+
+    expect(result).toEqual(baseRecord(text));
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("parses structured JSON summaries", () => {
+    const payload = JSON.stringify({
+      info: "Packet info",
+      summary: "Detailed summary",
+      time: "10:15:00",
+      src: "10.0.0.1",
+      dst: "10.0.0.2",
+      protocol: "TCP",
+      length: 1500,
+      extra: "value",
+    });
+
+    const result = parsePacketSummaryLine(payload);
+
+    expect(result).toMatchObject({
+      info: "Packet info",
+      summary: "Detailed summary",
+      time: "10:15:00",
+      src: "10.0.0.1",
+      dst: "10.0.0.2",
+      protocol: "TCP",
+      length: 1500,
+      extra: "value",
+    });
+  });
+
+  it("ignores JSON parsing for non-object strings", () => {
+    const spy = vi.spyOn(JSON, "parse");
+    const notJsonObject = "[1, 2, 3]";
+
+    const result = parsePacketSummaryLine(notJsonObject);
+
+    expect(result).toEqual(baseRecord(notJsonObject));
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("skips parsing invalid object-like text", () => {
+    const spy = vi.spyOn(JSON, "parse");
+    const invalid = '{"info": "Missing brace"';
+
+    const result = parsePacketSummaryLine(invalid);
+
+    expect(result).toEqual(baseRecord(invalid));
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/docs/src/summary.ts
+++ b/docs/src/summary.ts
@@ -1,0 +1,144 @@
+import type { PacketRecord as FilterPacketRecord } from "./filter";
+
+function toOptionalString(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function toOptionalNumericLike(value: unknown): string | number | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "boolean") {
+    return value ? "1" : "0";
+  }
+  return undefined;
+}
+
+function looksLikeJsonObject(value: string): boolean {
+  return value.startsWith("{") && value.endsWith("}");
+}
+
+export function parsePacketSummaryLine(line: string): FilterPacketRecord {
+  const trimmed = line.trim();
+  const record: FilterPacketRecord = { info: trimmed, summary: trimmed };
+
+  if (trimmed.length === 0) {
+    return record;
+  }
+
+  if (!looksLikeJsonObject(trimmed)) {
+    return record;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return record;
+    }
+
+    const data = parsed as Record<string, unknown>;
+
+    const infoValue =
+      toOptionalString(data.info) ??
+      toOptionalString(data.Info) ??
+      toOptionalString(data.summary) ??
+      toOptionalString(data.Summary);
+    if (infoValue) {
+      record.info = infoValue;
+    }
+
+    const summaryValue =
+      toOptionalString(data.summary) ?? toOptionalString(data.Summary);
+    if (summaryValue) {
+      record.summary = summaryValue;
+    }
+
+    const timeValue =
+      toOptionalString(data.time) ??
+      toOptionalString(data.timestamp) ??
+      toOptionalString(data.Time) ??
+      toOptionalString(data.Timestamp);
+    if (timeValue) {
+      record.time = timeValue;
+    }
+
+    const srcValue =
+      toOptionalString(data.src) ??
+      toOptionalString(data.source) ??
+      toOptionalString(data.Source);
+    if (srcValue) {
+      record.src = srcValue;
+      record.source = srcValue;
+    }
+
+    const dstValue =
+      toOptionalString(data.dst) ??
+      toOptionalString(data.destination) ??
+      toOptionalString(data.Dst) ??
+      toOptionalString(data.Destination);
+    if (dstValue) {
+      record.dst = dstValue;
+      record.destination = dstValue;
+    }
+
+    const protocolValue =
+      toOptionalString(data.protocol) ??
+      toOptionalString(data.proto) ??
+      toOptionalString(data.Protocol) ??
+      toOptionalString(data.Proto);
+    if (protocolValue) {
+      record.protocol = protocolValue;
+    }
+
+    const lengthValue =
+      toOptionalNumericLike(data.length) ??
+      toOptionalNumericLike(data.len) ??
+      toOptionalNumericLike(data.size) ??
+      toOptionalNumericLike(data.Length) ??
+      toOptionalNumericLike(data.Len) ??
+      toOptionalNumericLike(data.Size);
+    if (lengthValue !== undefined) {
+      record.length = lengthValue;
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+      if (value === null || value === undefined) {
+        continue;
+      }
+      if (key in record) {
+        continue;
+      }
+      if (typeof value === "string" || typeof value === "number") {
+        record[key] = value;
+        continue;
+      }
+      if (typeof value === "boolean") {
+        record[key] = value ? "true" : "false";
+      }
+    }
+
+    record.summary ??= record.info;
+    return record;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.debug("Failed to parse packet summary line", error);
+    }
+  }
+
+  return record;
+}


### PR DESCRIPTION
## Summary
- move packet summary parsing helpers into a dedicated summary utility
- skip JSON.parse for plain-text packet summaries while preserving structured parsing
- add vitest coverage to verify plain text skips JSON parsing and structured JSON still works

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1666603a08328b3cf39bd83d178f3