### PR TITLE
Add structured packet summaries to Wasm processor

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -18,14 +18,28 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 name = "core"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "once_cell"
@@ -56,6 +70,55 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "syn"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 wasm-bindgen = "0.2"
 
 [package.metadata.wasm-pack.profile.release]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,11 +1,137 @@
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-/// Process a packet payload and return a placeholder response.
+#[derive(Serialize)]
+struct PacketSummary<'a> {
+    info: &'a str,
+    summary: &'a str,
+    time: &'a str,
+    src: &'a str,
+    dst: &'a str,
+    protocol: &'a str,
+    length: usize,
+    hex_preview: &'a str,
+    ascii_preview: &'a str,
+}
+
+#[derive(Serialize)]
+struct Packet<'a> {
+    time: &'a str,
+    source: &'a str,
+    destination: &'a str,
+    protocol: &'a str,
+    length: usize,
+    info: String,
+    payload: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct PacketProcessingResult<'a> {
+    packets: Vec<Packet<'a>>,
+    warnings: Vec<&'a str>,
+    errors: Vec<&'a str>,
+}
+
+fn build_hex_preview(bytes: &[u8], max_len: usize) -> String {
+    let preview_len = bytes.len().min(max_len);
+    let mut preview = bytes
+        .iter()
+        .take(preview_len)
+        .map(|byte| format!("{:02X}", byte))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if bytes.len() > preview_len {
+        preview.push_str(" …");
+    }
+
+    preview
+}
+
+fn build_ascii_preview(bytes: &[u8], max_len: usize) -> String {
+    let preview_len = bytes.len().min(max_len);
+    let mut preview = String::with_capacity(preview_len);
+
+    for byte in bytes.iter().take(preview_len) {
+        let ch = *byte;
+        if (0x20..=0x7E).contains(&ch) {
+            preview.push(ch as char);
+        } else {
+            preview.push('.');
+        }
+    }
+
+    if bytes.len() > preview_len {
+        preview.push_str("…");
+    }
+
+    preview
+}
+
+fn build_info_payload<'a>(
+    total_bytes: usize,
+    hex_preview: &'a str,
+    ascii_preview: &'a str,
+) -> PacketSummary<'a> {
+    let base_summary = if total_bytes == 1 {
+        "Analyzed 1 byte"
+    } else {
+        "Analyzed payload"
+    };
+
+    PacketSummary {
+        info: base_summary,
+        summary: base_summary,
+        time: "0.000000",
+        src: "upload",
+        dst: "—",
+        protocol: "RAW",
+        length: total_bytes,
+        hex_preview,
+        ascii_preview,
+    }
+}
+
+fn serialize_result(result: &PacketProcessingResult) -> String {
+    serde_json::to_string(result)
+        .unwrap_or_else(|_| "{\"packets\":[],\"warnings\":[],\"errors\":[]}".into())
+}
+
+/// Process a packet payload and return a structured JSON response.
 ///
-/// This function will eventually parse the provided bytes and produce
-/// structured information for the UI. For now it only returns a string
-/// that echoes the length of the payload.
+/// The output mirrors the shape that the frontend expects from the
+/// WebAssembly module: a JSON object with `packets`, `warnings`, and
+/// `errors` arrays. Each packet includes the raw payload bytes alongside
+/// a JSON encoded summary string that can be parsed for additional
+/// metadata.
 #[wasm_bindgen]
 pub fn process_packet(data: &[u8]) -> String {
-    format!("Received {} bytes", data.len())
+    if data.is_empty() {
+        return serialize_result(&PacketProcessingResult {
+            packets: Vec::new(),
+            warnings: vec!["Empty payload provided"],
+            errors: Vec::new(),
+        });
+    }
+
+    let hex_preview = build_hex_preview(data, 32);
+    let ascii_preview = build_ascii_preview(data, 32);
+    let info_payload = build_info_payload(data.len(), &hex_preview, &ascii_preview);
+
+    let packet = Packet {
+        time: info_payload.time,
+        source: "upload",
+        destination: "—",
+        protocol: info_payload.protocol,
+        length: data.len(),
+        info: serde_json::to_string(&info_payload)
+            .unwrap_or_else(|_| "{\"info\":\"Analyzed payload\"}".into()),
+        payload: data.to_vec(),
+    };
+
+    serialize_result(&PacketProcessingResult {
+        packets: vec![packet],
+        warnings: Vec::new(),
+        errors: Vec::new(),
+    })
 }


### PR DESCRIPTION
## Summary
- return a structured JSON document from the Wasm packet processor including previews of the payload
- add serde-based serialization helpers to build packet summaries and empty-payload warnings

## Testing
- cargo test
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ddcf5db2f8832894b74d2059f91dfa