### PR TITLE
Add filter assistant UI with suggestions and history

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,6 +13,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
@@ -21,11 +24,74 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "jsdom": "^27.0.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
         "vite": "^7.1.2",
         "vitest": "^2.1.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+      "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.7.tgz",
+      "integrity": "sha512-cvdTPsi2qC1c22UppvuVmx/PDwuc6+QQkwt9OnwQD6Uotbh//tb2XDF0OoK2V0F4b8d02LIwNp3BieaDMAhIhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.2"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -261,6 +327,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -307,6 +383,144 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1346,6 +1560,104 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1836,6 +2148,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1851,6 +2173,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1875,6 +2208,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1901,6 +2244,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2095,12 +2448,62 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2120,6 +2523,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2137,12 +2547,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.221",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
       "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2607,6 +3048,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2644,6 +3139,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2677,6 +3182,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2702,6 +3214,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2815,6 +3367,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -2824,6 +3387,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2847,6 +3417,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2965,6 +3545,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3061,6 +3654,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3113,10 +3736,42 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3185,6 +3840,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3207,6 +3869,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3279,6 +3961,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3304,6 +3999,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3397,6 +4099,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3408,6 +4130,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4724,6 +5472,66 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4766,6 +5574,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
@@ -24,6 +27,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^27.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",

--- a/docs/src/App.css
+++ b/docs/src/App.css
@@ -198,7 +198,30 @@
   color: rgba(148, 163, 184, 0.85);
 }
 
-.filter-input input {
+.filter-assistant {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.filter-input-wrapper {
+  position: relative;
+}
+
+.filter-input-overlay {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0.45rem 0.6rem;
+  font: inherit;
+  white-space: pre-wrap;
+  color: transparent;
+  pointer-events: none;
+  border-radius: 6px;
+}
+
+.filter-input-wrapper input {
   background: rgba(15, 23, 42, 0.8);
   border: 1px solid rgba(59, 130, 246, 0.25);
   border-radius: 6px;
@@ -208,9 +231,102 @@
   min-width: min(320px, 100%);
 }
 
-.filter-input input[aria-invalid="true"] {
+.filter-input-wrapper input[aria-invalid="true"] {
   border-color: rgba(248, 113, 113, 0.6);
   box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.35);
+}
+
+.filter-input-error-highlight {
+  background: rgba(248, 113, 113, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.6);
+  border-radius: 4px;
+  color: transparent;
+}
+
+.filter-input-error-highlight[data-empty="true"] {
+  display: inline-block;
+  min-width: 0.3rem;
+}
+
+.filter-input-wrapper input:disabled {
+  opacity: 0.7;
+}
+
+.filter-suggestions {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  z-index: 5;
+  background: rgba(10, 16, 31, 0.95);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  box-shadow:
+    0 12px 32px -24px rgba(59, 130, 246, 0.8),
+    0 18px 40px -28px rgba(15, 23, 42, 0.7);
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.filter-suggestion {
+  margin: 0;
+}
+
+.filter-suggestion button {
+  width: 100%;
+  border: none;
+  background: none;
+  color: rgba(226, 232, 240, 0.9);
+  padding: 0.4rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.85rem;
+}
+
+.filter-suggestion button:hover {
+  background: rgba(59, 130, 246, 0.16);
+}
+
+.filter-suggestion.active button {
+  background: rgba(37, 99, 235, 0.22);
+}
+
+.suggestion-label {
+  font-weight: 600;
+}
+
+.suggestion-description {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.filter-history {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.filter-history-chip {
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(30, 64, 175, 0.2);
+  color: rgba(191, 219, 254, 0.95);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.filter-history-chip:hover {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(59, 130, 246, 0.5);
 }
 
 .filter-right {
@@ -235,10 +351,6 @@
 .filter-error {
   color: #fca5a5;
   font-weight: 500;
-}
-
-.filter-input input:disabled {
-  opacity: 0.7;
 }
 
 .filter-controls {

--- a/docs/src/App.css
+++ b/docs/src/App.css
@@ -321,7 +321,9 @@
   padding: 0.25rem 0.65rem;
   font-size: 0.75rem;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .filter-history-chip:hover {

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -2,11 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
 import {
   evaluateFilter,
-  parseFilter,
-  tokenizeFilter,
   type FilterNode,
   type PacketRecord as FilterPacketRecord,
 } from "./filter";
+import FilterInput, { type FilterChangeDetails } from "./FilterInput";
 import { parsePacketSummaryLine } from "./summary";
 import { loadProcessor, type PacketRecord as WasmPacketRecord } from "./wasm";
 
@@ -364,34 +363,10 @@ function App() {
   );
 
   const onFilterChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      setFilterText(value);
-
-      const trimmed = value.trim();
-      if (trimmed.length === 0) {
-        setFilterAst(null);
-        setFilterError(null);
-        return;
-      }
-
-      try {
-        const tokens = tokenizeFilter(value);
-        if (tokens.length === 0) {
-          setFilterAst(null);
-          setFilterError(null);
-          return;
-        }
-        const node = parseFilter(tokens);
-        setFilterAst(node);
-        setFilterError(null);
-      } catch (err) {
-        console.debug("Failed to parse display filter", err);
-        setFilterAst(null);
-        setFilterError(
-          "Invalid display filter. Use AND/OR/NOT with parentheses or quotes.",
-        );
-      }
+    ({ text, ast, errorMessage }: FilterChangeDetails) => {
+      setFilterText(text);
+      setFilterAst(ast);
+      setFilterError(errorMessage);
     },
     [],
   );
@@ -638,21 +613,14 @@ function App() {
         </div>
 
         <div className="filter-bar">
-          <label className="filter-input" htmlFor="display-filter">
-            <span>Display filter</span>
-            <input
-              id="display-filter"
-              type="text"
-              placeholder="tcp && http"
-              spellCheck={false}
-              value={filterText}
-              onChange={onFilterChange}
-              aria-invalid={filterError ? true : false}
-              aria-describedby={
-                filterError ? "display-filter-error" : undefined
-              }
-            />
-          </label>
+          <FilterInput
+            id="display-filter"
+            label="Display filter"
+            placeholder="tcp && http"
+            value={filterText}
+            describedById={filterError ? "display-filter-error" : undefined}
+            onFilterChange={onFilterChange}
+          />
           <div className="filter-right">
             <div className="filter-meta" aria-live="polite">
               {filterError ? (

--- a/docs/src/FilterInput.test.tsx
+++ b/docs/src/FilterInput.test.tsx
@@ -1,0 +1,86 @@
+import { describe, beforeEach, afterEach, expect, it } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import userEvent from "@testing-library/user-event";
+import FilterInput, { type FilterChangeDetails } from "./FilterInput";
+import { createStoredList } from "./storage";
+
+const historyStore = createStoredList("pipe-lion.filter-history", 8);
+
+type HarnessResult = {
+  getLastChange: () => FilterChangeDetails | null;
+};
+
+function renderFilterInput(): HarnessResult {
+  let lastChange: FilterChangeDetails | null = null;
+
+  function Harness() {
+    const [text, setText] = useState("");
+    return (
+      <FilterInput
+        id="display-filter"
+        label="Display filter"
+        value={text}
+        onFilterChange={(details) => {
+          lastChange = details;
+          setText(details.text);
+        }}
+      />
+    );
+  }
+
+  render(<Harness />);
+
+  return {
+    getLastChange: () => lastChange,
+  };
+}
+
+describe("FilterInput", () => {
+  beforeEach(() => {
+    historyStore.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("surfaces field suggestions and supports keyboard navigation", async () => {
+    const user = userEvent.setup();
+    renderFilterInput();
+
+    const input = screen.getByLabelText(/display filter/i);
+    await user.click(input);
+    await user.type(input, "pro");
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute("aria-expanded", "true");
+    });
+
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toHaveTextContent(/protocol/i);
+
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(input).toHaveValue("protocol ");
+
+    const operatorOption = await screen.findByRole("option", {
+      name: /==/i,
+    });
+    expect(operatorOption).toBeInTheDocument();
+  });
+
+  it("marks the input invalid and exposes error details for malformed filters", async () => {
+    const user = userEvent.setup();
+    const { getLastChange } = renderFilterInput();
+
+    const input = screen.getAllByLabelText(/display filter/i)[0];
+    await user.click(input);
+    await user.type(input, "protocol ==");
+
+    expect(await screen.findByTestId("filter-error-highlight")).toBeVisible();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    const lastChange = getLastChange();
+    expect(lastChange?.errorMessage).toMatch(/comparison operator/i);
+  });
+});

--- a/docs/src/FilterInput.tsx
+++ b/docs/src/FilterInput.tsx
@@ -1,0 +1,730 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  analyzeFilter,
+  FIELD_ALIASES,
+  FilterSyntaxError,
+  type FilterAnalysis,
+  type FilterNode,
+  type FilterTokenWithRange,
+} from "./filter";
+import { createStoredList } from "./storage";
+
+type FilterChangeDetails = {
+  text: string;
+  ast: FilterNode | null;
+  error: FilterSyntaxError | null;
+  errorMessage: string | null;
+};
+
+type FilterInputProps = {
+  id: string;
+  label: string;
+  placeholder?: string;
+  describedById?: string;
+  value?: string;
+  onFilterChange(details: FilterChangeDetails): void;
+};
+
+type SuggestionContext = "field" | "operator" | "value" | "logical";
+
+type SuggestionItem = {
+  value: string;
+  label: string;
+  description?: string;
+  kind: SuggestionContext | "not";
+};
+
+type ActiveSegment = { start: number; text: string };
+
+const FIELD_ALIAS_MAP = (() => {
+  const map = new Map<
+    string,
+    { alias: string; canonical: string; aliases: string[] }
+  >();
+
+  for (const [canonical, aliases] of Object.entries(FIELD_ALIASES)) {
+    const canonicalName = aliases[0];
+    const uniqueAliases = Array.from(new Set(aliases));
+    for (const alias of uniqueAliases) {
+      const lower = alias.toLowerCase();
+      if (!map.has(lower)) {
+        map.set(lower, {
+          alias,
+          canonical: canonicalName,
+          aliases: uniqueAliases,
+        });
+      }
+    }
+  }
+
+  return map;
+})();
+
+const FIELD_ALIAS_KEYS = Array.from(FIELD_ALIAS_MAP.keys());
+
+const FIELD_SUGGESTIONS: SuggestionItem[] = Array.from(
+  FIELD_ALIAS_MAP.values(),
+)
+  .map((info) => {
+    const description =
+      info.alias !== info.canonical ? `Field: ${info.canonical}` : undefined;
+    return {
+      value: info.alias,
+      label: info.alias,
+      description,
+      kind: "field" as const,
+    };
+  })
+  .sort((a, b) => a.label.localeCompare(b.label));
+
+const OPERATOR_SUGGESTIONS: SuggestionItem[] = [
+  { value: "==", label: "==", description: "Equals", kind: "operator" },
+  {
+    value: "contains",
+    label: "contains",
+    description: "Substring match",
+    kind: "operator",
+  },
+];
+
+const LOGICAL_SUGGESTIONS: SuggestionItem[] = [
+  { value: "&&", label: "&&", description: "Logical AND", kind: "logical" },
+  { value: "||", label: "||", description: "Logical OR", kind: "logical" },
+  { value: "and", label: "and", description: "AND keyword", kind: "logical" },
+  { value: "or", label: "or", description: "OR keyword", kind: "logical" },
+  {
+    value: "not",
+    label: "not",
+    description: "Negate the next term",
+    kind: "logical",
+  },
+];
+
+const HISTORY_STORE_KEY = "pipe-lion.filter-history";
+const HISTORY_LIMIT = 8;
+
+const historyStore = createStoredList(HISTORY_STORE_KEY, HISTORY_LIMIT);
+
+function hasAliasPrefix(prefix: string) {
+  const lowered = prefix.toLowerCase();
+  if (!lowered) {
+    return false;
+  }
+  return FIELD_ALIAS_KEYS.some((alias) => alias.startsWith(lowered));
+}
+
+function advanceExpectation(
+  expectation: SuggestionContext,
+  token: FilterTokenWithRange,
+): SuggestionContext {
+  switch (expectation) {
+    case "field": {
+      if (token.type === "NOT" || token.type === "LPAREN") {
+        return "field";
+      }
+      if (token.type === "TEXT") {
+        const lowered = token.value.toLowerCase();
+        if (FIELD_ALIAS_MAP.has(lowered) || hasAliasPrefix(lowered)) {
+          return "operator";
+        }
+        return "logical";
+      }
+      if (token.type === "RPAREN") {
+        return "logical";
+      }
+      return expectation;
+    }
+    case "operator": {
+      if (token.type === "EQ" || token.type === "CONTAINS") {
+        return "value";
+      }
+      if (token.type === "TEXT") {
+        return "logical";
+      }
+      return expectation;
+    }
+    case "value": {
+      if (token.type === "TEXT") {
+        return "logical";
+      }
+      if (token.type === "LPAREN") {
+        return "field";
+      }
+      return expectation;
+    }
+    case "logical": {
+      if (token.type === "AND" || token.type === "OR") {
+        return "field";
+      }
+      if (token.type === "RPAREN") {
+        return "logical";
+      }
+      if (token.type === "NOT") {
+        return "field";
+      }
+      return expectation;
+    }
+    default:
+      return expectation;
+  }
+}
+
+function getActiveSegment(value: string, caret: number): ActiveSegment {
+  let start = caret;
+  while (start > 0) {
+    const char = value[start - 1];
+    if (/[ \t\n\r()&|!]/.test(char)) {
+      break;
+    }
+    if (char === "=") {
+      break;
+    }
+    start -= 1;
+  }
+  return { start, text: value.slice(start, caret) };
+}
+
+function computeSuggestionContext(
+  analysis: FilterAnalysis,
+  caret: number,
+  segment: ActiveSegment,
+): SuggestionContext {
+  let expectation: SuggestionContext = "field";
+
+  for (const token of analysis.tokens) {
+    if (token.end <= caret) {
+      expectation = advanceExpectation(expectation, token);
+      continue;
+    }
+
+    if (token.start < caret && caret <= token.end) {
+      if (token.type === "TEXT") {
+        return expectation;
+      }
+      return expectation;
+    }
+
+    break;
+  }
+
+  if (expectation === "field" && segment.text) {
+    const lowered = segment.text.toLowerCase();
+    if (FIELD_ALIAS_MAP.has(lowered) || hasAliasPrefix(lowered)) {
+      return "operator";
+    }
+  }
+
+  return expectation;
+}
+
+function filterSuggestions(
+  items: SuggestionItem[],
+  prefix: string,
+  limit = 8,
+): SuggestionItem[] {
+  const lowered = prefix.toLowerCase();
+  const filtered = lowered
+    ? items.filter((item) => item.value.toLowerCase().startsWith(lowered))
+    : items;
+  return filtered.slice(0, limit);
+}
+
+function formatErrorMessage(error: FilterSyntaxError | null): string | null {
+  if (!error) {
+    return null;
+  }
+
+  switch (error.message) {
+    case "Unexpected '&'":
+      return "Use '&&' to join filters with AND.";
+    case "Unexpected '|'":
+      return "Use '||' to join filters with OR.";
+    case "Unexpected '='":
+      return "Use '==' for equality comparisons.";
+    case "Expected comparison value":
+      return "Expected a quoted value after the comparison operator.";
+    case "Unexpected trailing tokens":
+      return "Remove the trailing text after the filter expression.";
+    case "Unexpected token":
+      return "Unexpected token in the filter expression.";
+    case "Unexpected end of expression":
+      return "Incomplete filter expression. Add another term.";
+    case "Expected filter term":
+      return "Expected a term or field after the operator.";
+    case "Unterminated quoted string":
+      return "Close the quoted string to finish the value.";
+    default:
+      return error.message;
+  }
+}
+
+function ensureSpaceBefore(before: string) {
+  if (!before) {
+    return false;
+  }
+  const char = before[before.length - 1];
+  return !/[\s(!&|]/.test(char);
+}
+
+function ensureSpaceAfter(after: string) {
+  if (!after) {
+    return true;
+  }
+  const char = after[0];
+  return !/[\s)|&]/.test(char);
+}
+
+function buildSuggestions(
+  context: SuggestionContext,
+  segment: ActiveSegment,
+): SuggestionItem[] {
+  const prefix = segment.text.trim();
+
+  if (context === "operator") {
+    const trimmed = segment.text.trim();
+    if (trimmed.length === 0) {
+      return filterSuggestions(OPERATOR_SUGGESTIONS, trimmed);
+    }
+    const fieldMatches = filterSuggestions(FIELD_SUGGESTIONS, trimmed);
+    if (fieldMatches.length > 0) {
+      return fieldMatches;
+    }
+    return filterSuggestions(OPERATOR_SUGGESTIONS, trimmed);
+  }
+
+  if (context === "logical") {
+    return filterSuggestions(LOGICAL_SUGGESTIONS, prefix);
+  }
+
+  if (context === "value") {
+    return [];
+  }
+
+  const fieldSuggestions = filterSuggestions(FIELD_SUGGESTIONS, prefix);
+  const includeNot = filterSuggestions(LOGICAL_SUGGESTIONS, prefix).filter(
+    (item) => item.value === "not",
+  );
+  return [...fieldSuggestions, ...includeNot];
+}
+
+export type { FilterChangeDetails };
+
+export default function FilterInput({
+  id,
+  label,
+  placeholder,
+  describedById,
+  value = "",
+  onFilterChange,
+}: FilterInputProps) {
+  const listboxId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const blurTimeoutRef = useRef<number | null>(null);
+  const pendingCaretRef = useRef<number | null>(null);
+  const selectionRef = useRef<{ start: number; end: number }>({
+    start: value.length,
+    end: value.length,
+  });
+
+  const [inputValue, setInputValue] = useState(value);
+  const [analysis, setAnalysis] = useState<FilterAnalysis>(() =>
+    analyzeFilter(value),
+  );
+  const [caret, setCaret] = useState(value.length);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isListOpen, setIsListOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [history, setHistory] = useState<string[]>(() => historyStore.load());
+
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current !== null) {
+        window.clearTimeout(blurTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (value !== inputValue) {
+      setInputValue(value);
+      setAnalysis(analyzeFilter(value));
+      const nextCaret = value.length;
+      setCaret(nextCaret);
+      selectionRef.current = { start: nextCaret, end: nextCaret };
+    }
+  }, [value, inputValue]);
+
+  useLayoutEffect(() => {
+    if (pendingCaretRef.current !== null && inputRef.current) {
+      const next = pendingCaretRef.current;
+      inputRef.current.setSelectionRange(next, next);
+      pendingCaretRef.current = null;
+    }
+  }, [inputValue]);
+
+  const segment = useMemo(
+    () => getActiveSegment(inputValue, caret),
+    [inputValue, caret],
+  );
+
+  const suggestionContext = useMemo(
+    () => computeSuggestionContext(analysis, caret, segment),
+    [analysis, caret, segment],
+  );
+
+  const suggestions = useMemo(() => {
+    if (!isFocused) {
+      return [];
+    }
+    return buildSuggestions(suggestionContext, segment);
+  }, [isFocused, segment, suggestionContext]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+    if (suggestions.length === 0) {
+      setIsListOpen(false);
+    } else if (isFocused) {
+      setIsListOpen(true);
+    }
+  }, [suggestions, isFocused]);
+
+  const emitChange = useCallback(
+    (text: string, nextCaret?: number) => {
+      setInputValue(text);
+      const nextAnalysis = analyzeFilter(text);
+      setAnalysis(nextAnalysis);
+      if (typeof nextCaret === "number") {
+        pendingCaretRef.current = nextCaret;
+      }
+
+      onFilterChange({
+        text,
+        ast: nextAnalysis.ast,
+        error: nextAnalysis.error,
+        errorMessage: formatErrorMessage(nextAnalysis.error),
+      });
+    },
+    [onFilterChange],
+  );
+
+  const rememberFilter = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) {
+        return;
+      }
+      const next = historyStore.remember(trimmed);
+      setHistory(next);
+    },
+    []);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextValue = event.target.value;
+      const selectionStart = event.target.selectionStart ?? nextValue.length;
+      const selectionEnd = event.target.selectionEnd ?? selectionStart;
+      selectionRef.current = { start: selectionStart, end: selectionEnd };
+      setCaret(selectionEnd);
+      emitChange(nextValue, selectionEnd);
+      setIsListOpen(true);
+    },
+    [emitChange],
+  );
+
+  const handleSelect = useCallback(
+    (event: React.SyntheticEvent<HTMLInputElement>) => {
+      const target = event.currentTarget;
+      const selectionStart = target.selectionStart ?? 0;
+      const selectionEnd = target.selectionEnd ?? selectionStart;
+      selectionRef.current = { start: selectionStart, end: selectionEnd };
+      setCaret(selectionEnd);
+    },
+    [],
+  );
+
+  const closeSuggestions = useCallback(() => {
+    setIsListOpen(false);
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    setIsFocused(true);
+    if (suggestions.length > 0) {
+      setIsListOpen(true);
+    }
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current);
+      blurTimeoutRef.current = null;
+    }
+  }, [suggestions]);
+
+  const handleBlur = useCallback(() => {
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current);
+    }
+    blurTimeoutRef.current = window.setTimeout(() => {
+      const active = document.activeElement;
+      if (!containerRef.current?.contains(active)) {
+        setIsFocused(false);
+        setIsListOpen(false);
+      }
+    }, 10);
+  }, []);
+
+  const applySuggestion = useCallback(
+    (item: SuggestionItem) => {
+      const { start, end } = selectionRef.current;
+      const caretPosition = end;
+      const activeSegment = getActiveSegment(inputValue, caretPosition);
+      const replaceFrom = start !== end ? start : activeSegment.start;
+      const before = inputValue.slice(0, replaceFrom);
+      const after = inputValue.slice(end);
+
+      const needsLeadingSpace = ensureSpaceBefore(before);
+      const needsTrailingSpace = ensureSpaceAfter(after);
+
+      let insertion = item.value;
+      const context = suggestionContext === "value" ? "value" : item.kind;
+
+      if (context === "operator" || context === "logical") {
+        insertion = `${item.value}`;
+        if (needsLeadingSpace) {
+          insertion = ` ${insertion}`;
+        }
+        if (needsTrailingSpace) {
+          insertion = `${insertion} `;
+        } else if (context !== "value") {
+          insertion = `${insertion}`;
+        }
+      } else if (context === "field") {
+        if (needsLeadingSpace) {
+          insertion = ` ${insertion}`;
+        }
+        if (needsTrailingSpace) {
+          insertion = `${insertion} `;
+        }
+      }
+
+      const nextValue = `${before}${insertion}${after}`;
+      const nextCaret = before.length + insertion.length;
+      selectionRef.current = { start: nextCaret, end: nextCaret };
+      setCaret(nextCaret);
+      emitChange(nextValue, nextCaret);
+      setIsListOpen(false);
+    },
+    [emitChange, inputValue, suggestionContext],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "ArrowDown" && suggestions.length > 0) {
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % suggestions.length);
+        setIsListOpen(true);
+        return;
+      }
+
+      if (event.key === "ArrowUp" && suggestions.length > 0) {
+        event.preventDefault();
+        setActiveIndex((index) =>
+          index === 0 ? suggestions.length - 1 : index - 1,
+        );
+        setIsListOpen(true);
+        return;
+      }
+
+      if (event.key === "Enter") {
+        if (isListOpen && suggestions.length > 0) {
+          event.preventDefault();
+          applySuggestion(suggestions[activeIndex]);
+          return;
+        }
+
+        if (analysis.ast && !analysis.error && inputValue.trim().length > 0) {
+          rememberFilter(inputValue);
+        }
+        closeSuggestions();
+        return;
+      }
+
+      if (event.key === "Tab" && isListOpen && suggestions.length > 0) {
+        event.preventDefault();
+        applySuggestion(suggestions[activeIndex]);
+        return;
+      }
+
+      if (event.key === "Escape" && isListOpen) {
+        event.preventDefault();
+        closeSuggestions();
+      }
+    },
+    [
+      activeIndex,
+      analysis.ast,
+      analysis.error,
+      applySuggestion,
+      closeSuggestions,
+      inputValue,
+      isListOpen,
+      rememberFilter,
+      suggestions,
+    ],
+  );
+
+  const handleSuggestionMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      // Prevent blurring the input before selection is applied.
+      event.preventDefault();
+    },
+    [],
+  );
+
+  const handleSuggestionClick = useCallback(
+    (item: SuggestionItem) => {
+      applySuggestion(item);
+      inputRef.current?.focus();
+    },
+    [applySuggestion],
+  );
+
+  const handleHistorySelect = useCallback(
+    (entry: string) => {
+      const trimmed = entry.trim();
+      const nextCaret = trimmed.length;
+      selectionRef.current = { start: nextCaret, end: nextCaret };
+      setCaret(nextCaret);
+      emitChange(trimmed, nextCaret);
+      rememberFilter(trimmed);
+      inputRef.current?.focus();
+    },
+    [emitChange, rememberFilter],
+  );
+
+  const errorRange = useMemo(() => {
+    if (!analysis.error) {
+      return null;
+    }
+    const start = Math.max(0, Math.min(analysis.error.start, inputValue.length));
+    const end = Math.max(start, Math.min(analysis.error.end, inputValue.length));
+    return { start, end };
+  }, [analysis.error, inputValue.length]);
+
+  const beforeError = errorRange
+    ? inputValue.slice(0, errorRange.start)
+    : inputValue;
+  const errorText = errorRange
+    ? inputValue.slice(errorRange.start, errorRange.end)
+    : "";
+  const afterError = errorRange ? inputValue.slice(errorRange.end) : "";
+
+  return (
+    <div className="filter-assistant" ref={containerRef}>
+      <label className="filter-input" htmlFor={id}>
+        <span>{label}</span>
+        <div
+          className="filter-input-wrapper"
+          data-has-error={analysis.error ? "true" : "false"}
+        >
+          <pre className="filter-input-overlay" aria-hidden="true">
+            {errorRange ? (
+              <>
+                <span>{beforeError}</span>
+                <span
+                  className="filter-input-error-highlight"
+                  data-testid="filter-error-highlight"
+                  data-empty={errorText.length === 0 ? "true" : undefined}
+                >
+                  {errorText.length > 0 ? errorText : "\u00a0"}
+                </span>
+                <span>{afterError}</span>
+              </>
+            ) : (
+              <span>{inputValue}</span>
+            )}
+          </pre>
+          <input
+            ref={inputRef}
+            id={id}
+            type="text"
+            value={inputValue}
+            placeholder={placeholder}
+            spellCheck={false}
+            aria-invalid={analysis.error ? true : false}
+            aria-describedby={describedById}
+            aria-autocomplete="list"
+            aria-expanded={isListOpen}
+            aria-controls={
+              isListOpen && suggestions.length > 0 ? listboxId : undefined
+            }
+            aria-activedescendant={
+              isListOpen && suggestions[activeIndex]
+                ? `${listboxId}-option-${activeIndex}`
+                : undefined
+            }
+            onChange={handleChange}
+            onSelect={handleSelect}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+          />
+        </div>
+      </label>
+
+      {isListOpen && suggestions.length > 0 ? (
+        <ul
+          className="filter-suggestions"
+          role="listbox"
+          id={listboxId}
+          onMouseDown={handleSuggestionMouseDown}
+        >
+          {suggestions.map((item, index) => (
+            <li
+              key={item.value + index}
+              id={`${listboxId}-option-${index}`}
+              role="option"
+              aria-selected={index === activeIndex}
+              className={
+                index === activeIndex
+                  ? "filter-suggestion active"
+                  : "filter-suggestion"
+              }
+            >
+              <button type="button" onClick={() => handleSuggestionClick(item)}>
+                <span className="suggestion-label">{item.label}</span>
+                {item.description ? (
+                  <span className="suggestion-description">
+                    {item.description}
+                  </span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {history.length > 0 ? (
+        <div className="filter-history" role="list">
+          {history.map((entry) => (
+            <button
+              key={entry}
+              type="button"
+              className="filter-history-chip"
+              onClick={() => handleHistorySelect(entry)}
+            >
+              {entry}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/src/FilterInput.tsx
+++ b/docs/src/FilterInput.tsx
@@ -70,9 +70,7 @@ const FIELD_ALIAS_MAP = (() => {
 
 const FIELD_ALIAS_KEYS = Array.from(FIELD_ALIAS_MAP.keys());
 
-const FIELD_SUGGESTIONS: SuggestionItem[] = Array.from(
-  FIELD_ALIAS_MAP.values(),
-)
+const FIELD_SUGGESTIONS: SuggestionItem[] = Array.from(FIELD_ALIAS_MAP.values())
   .map((info) => {
     const description =
       info.alias !== info.canonical ? `Field: ${info.canonical}` : undefined;
@@ -416,16 +414,14 @@ export default function FilterInput({
     [onFilterChange],
   );
 
-  const rememberFilter = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed) {
-        return;
-      }
-      const next = historyStore.remember(trimmed);
-      setHistory(next);
-    },
-    []);
+  const rememberFilter = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+    const next = historyStore.remember(trimmed);
+    setHistory(next);
+  }, []);
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -579,13 +575,10 @@ export default function FilterInput({
     ],
   );
 
-  const handleSuggestionMouseDown = useCallback(
-    (event: React.MouseEvent) => {
-      // Prevent blurring the input before selection is applied.
-      event.preventDefault();
-    },
-    [],
-  );
+  const handleSuggestionMouseDown = useCallback((event: React.MouseEvent) => {
+    // Prevent blurring the input before selection is applied.
+    event.preventDefault();
+  }, []);
 
   const handleSuggestionClick = useCallback(
     (item: SuggestionItem) => {
@@ -612,8 +605,14 @@ export default function FilterInput({
     if (!analysis.error) {
       return null;
     }
-    const start = Math.max(0, Math.min(analysis.error.start, inputValue.length));
-    const end = Math.max(start, Math.min(analysis.error.end, inputValue.length));
+    const start = Math.max(
+      0,
+      Math.min(analysis.error.start, inputValue.length),
+    );
+    const end = Math.max(
+      start,
+      Math.min(analysis.error.end, inputValue.length),
+    );
     return { start, end };
   }, [analysis.error, inputValue.length]);
 

--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -97,7 +97,12 @@ function tokenizeFilterDetailed(expression: string): FilterTokenWithRange[] {
     if (char === "&") {
       if (expression[index + 1] === "&") {
         tokens.push(
-          createToken({ type: "AND" }, index, index + 2, expression.slice(index, index + 2)),
+          createToken(
+            { type: "AND" },
+            index,
+            index + 2,
+            expression.slice(index, index + 2),
+          ),
         );
         index += 2;
         continue;
@@ -112,7 +117,12 @@ function tokenizeFilterDetailed(expression: string): FilterTokenWithRange[] {
     if (char === "|") {
       if (expression[index + 1] === "|") {
         tokens.push(
-          createToken({ type: "OR" }, index, index + 2, expression.slice(index, index + 2)),
+          createToken(
+            { type: "OR" },
+            index,
+            index + 2,
+            expression.slice(index, index + 2),
+          ),
         );
         index += 2;
         continue;
@@ -133,7 +143,12 @@ function tokenizeFilterDetailed(expression: string): FilterTokenWithRange[] {
     if (char === "=") {
       if (expression[index + 1] === "=") {
         tokens.push(
-          createToken({ type: "EQ" }, index, index + 2, expression.slice(index, index + 2)),
+          createToken(
+            { type: "EQ" },
+            index,
+            index + 2,
+            expression.slice(index, index + 2),
+          ),
         );
         index += 2;
         continue;
@@ -182,7 +197,12 @@ function tokenizeFilterDetailed(expression: string): FilterTokenWithRange[] {
       }
 
       tokens.push(
-        createToken({ type: "TEXT", value }, start, index, expression.slice(start, index)),
+        createToken(
+          { type: "TEXT", value },
+          start,
+          index,
+          expression.slice(start, index),
+        ),
       );
       continue;
     }
@@ -229,7 +249,9 @@ function tokenizeFilterDetailed(expression: string): FilterTokenWithRange[] {
 }
 
 export function tokenizeFilter(expression: string): FilterToken[] {
-  return tokenizeFilterDetailed(expression).map(({ start, end, raw, ...token }) => token);
+  return tokenizeFilterDetailed(expression).map(
+    ({ start, end, raw, ...token }) => token,
+  );
 }
 
 type ParseOptions = {
@@ -322,10 +344,10 @@ export function parseFilter(
   function parsePrimary(): FilterNode {
     const token = tokens[index];
     if (!token) {
-      throw new FilterSyntaxError(
-        "Unexpected end of expression",
-        { start: inputLength, end: inputLength },
-      );
+      throw new FilterSyntaxError("Unexpected end of expression", {
+        start: inputLength,
+        end: inputLength,
+      });
     }
 
     if (token.type === "TEXT") {

--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -34,8 +34,44 @@ export type FilterToken =
   | { type: "CONTAINS" }
   | { type: "TEXT"; value: string };
 
-export function tokenizeFilter(expression: string): FilterToken[] {
-  const tokens: FilterToken[] = [];
+export type FilterTokenWithRange = FilterToken & {
+  start: number;
+  end: number;
+  raw: string;
+};
+
+export class FilterSyntaxError extends Error {
+  start: number;
+  end: number;
+  tokens?: FilterTokenWithRange[];
+
+  constructor(
+    message: string,
+    range?: { start: number; end: number },
+    tokens?: FilterTokenWithRange[],
+  ) {
+    super(message);
+    this.name = "FilterSyntaxError";
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.start = range?.start ?? 0;
+    this.end = range?.end ?? this.start;
+    if (tokens) {
+      this.tokens = tokens;
+    }
+  }
+}
+
+function createToken(
+  token: FilterToken,
+  start: number,
+  end: number,
+  raw: string,
+): FilterTokenWithRange {
+  return { ...token, start, end, raw };
+}
+
+function tokenizeFilterDetailed(expression: string): FilterTokenWithRange[] {
+  const tokens: FilterTokenWithRange[] = [];
   let index = 0;
 
   while (index < expression.length) {
@@ -47,48 +83,66 @@ export function tokenizeFilter(expression: string): FilterToken[] {
     }
 
     if (char === "(") {
-      tokens.push({ type: "LPAREN" });
+      tokens.push(createToken({ type: "LPAREN" }, index, index + 1, char));
       index += 1;
       continue;
     }
 
     if (char === ")") {
-      tokens.push({ type: "RPAREN" });
+      tokens.push(createToken({ type: "RPAREN" }, index, index + 1, char));
       index += 1;
       continue;
     }
 
     if (char === "&") {
       if (expression[index + 1] === "&") {
-        tokens.push({ type: "AND" });
+        tokens.push(
+          createToken({ type: "AND" }, index, index + 2, expression.slice(index, index + 2)),
+        );
         index += 2;
         continue;
       }
-      throw new Error("Unexpected '&'");
+      throw new FilterSyntaxError(
+        "Unexpected '&'",
+        { start: index, end: index + 1 },
+        tokens,
+      );
     }
 
     if (char === "|") {
       if (expression[index + 1] === "|") {
-        tokens.push({ type: "OR" });
+        tokens.push(
+          createToken({ type: "OR" }, index, index + 2, expression.slice(index, index + 2)),
+        );
         index += 2;
         continue;
       }
-      throw new Error("Unexpected '|'");
+      throw new FilterSyntaxError(
+        "Unexpected '|'",
+        { start: index, end: index + 1 },
+        tokens,
+      );
     }
 
     if (char === "!") {
-      tokens.push({ type: "NOT" });
+      tokens.push(createToken({ type: "NOT" }, index, index + 1, char));
       index += 1;
       continue;
     }
 
     if (char === "=") {
       if (expression[index + 1] === "=") {
-        tokens.push({ type: "EQ" });
+        tokens.push(
+          createToken({ type: "EQ" }, index, index + 2, expression.slice(index, index + 2)),
+        );
         index += 2;
         continue;
       }
-      throw new Error("Unexpected '='");
+      throw new FilterSyntaxError(
+        "Unexpected '='",
+        { start: index, end: index + 1 },
+        tokens,
+      );
     }
 
     if (char === '"' || char === "'") {
@@ -96,6 +150,7 @@ export function tokenizeFilter(expression: string): FilterToken[] {
       index += 1;
       let value = "";
       let closed = false;
+      const start = index - 1;
 
       while (index < expression.length) {
         const current = expression[index];
@@ -119,10 +174,16 @@ export function tokenizeFilter(expression: string): FilterToken[] {
       }
 
       if (!closed) {
-        throw new Error("Unterminated quoted string");
+        throw new FilterSyntaxError(
+          "Unterminated quoted string",
+          { start, end: expression.length },
+          tokens,
+        );
       }
 
-      tokens.push({ type: "TEXT", value });
+      tokens.push(
+        createToken({ type: "TEXT", value }, start, index, expression.slice(start, index)),
+      );
       continue;
     }
 
@@ -138,22 +199,22 @@ export function tokenizeFilter(expression: string): FilterToken[] {
     const lowered = raw.toLowerCase();
 
     if (lowered === "and") {
-      tokens.push({ type: "AND" });
+      tokens.push(createToken({ type: "AND" }, start, index, raw));
       continue;
     }
 
     if (lowered === "or") {
-      tokens.push({ type: "OR" });
+      tokens.push(createToken({ type: "OR" }, start, index, raw));
       continue;
     }
 
     if (lowered === "not") {
-      tokens.push({ type: "NOT" });
+      tokens.push(createToken({ type: "NOT" }, start, index, raw));
       continue;
     }
 
     if (lowered === "contains") {
-      tokens.push({ type: "CONTAINS" });
+      tokens.push(createToken({ type: "CONTAINS" }, start, index, raw));
       continue;
     }
 
@@ -161,14 +222,41 @@ export function tokenizeFilter(expression: string): FilterToken[] {
       continue;
     }
 
-    tokens.push({ type: "TEXT", value: raw });
+    tokens.push(createToken({ type: "TEXT", value: raw }, start, index, raw));
   }
 
   return tokens;
 }
 
-export function parseFilter(tokens: FilterToken[]): FilterNode {
+export function tokenizeFilter(expression: string): FilterToken[] {
+  return tokenizeFilterDetailed(expression).map(({ start, end, raw, ...token }) => token);
+}
+
+type ParseOptions = {
+  metadata?: FilterTokenWithRange[];
+  inputLength?: number;
+};
+
+function rangeFor(
+  metadata: FilterTokenWithRange[] | undefined,
+  tokenIndex: number,
+  fallback: number,
+): { start: number; end: number } {
+  const token = metadata?.[tokenIndex];
+  if (token) {
+    return { start: token.start, end: token.end };
+  }
+  return { start: fallback, end: fallback };
+}
+
+export function parseFilter(
+  tokens: FilterToken[],
+  options: ParseOptions = {},
+): FilterNode {
   let index = 0;
+  const metadata = options.metadata;
+  const inputLength =
+    options.inputLength ?? metadata?.[metadata.length - 1]?.end ?? 0;
 
   function parseExpression(): FilterNode {
     return parseOr();
@@ -212,7 +300,10 @@ export function parseFilter(tokens: FilterToken[]): FilterNode {
         continue;
       }
 
-      throw new Error("Unexpected token");
+      throw new FilterSyntaxError(
+        "Unexpected token",
+        rangeFor(metadata, index, inputLength),
+      );
     }
 
     return node;
@@ -231,7 +322,10 @@ export function parseFilter(tokens: FilterToken[]): FilterNode {
   function parsePrimary(): FilterNode {
     const token = tokens[index];
     if (!token) {
-      throw new Error("Unexpected end of expression");
+      throw new FilterSyntaxError(
+        "Unexpected end of expression",
+        { start: inputLength, end: inputLength },
+      );
     }
 
     if (token.type === "TEXT") {
@@ -239,7 +333,10 @@ export function parseFilter(tokens: FilterToken[]): FilterNode {
       if (next && (next.type === "EQ" || next.type === "CONTAINS")) {
         const valueToken = tokens[index + 2];
         if (!valueToken || valueToken.type !== "TEXT") {
-          throw new Error("Expected comparison value");
+          throw new FilterSyntaxError(
+            "Expected comparison value",
+            rangeFor(metadata, index + 1, inputLength),
+          );
         }
 
         const operator = next.type === "EQ" ? "eq" : "contains";
@@ -257,25 +354,99 @@ export function parseFilter(tokens: FilterToken[]): FilterNode {
       index += 1;
       const node = parseExpression();
       if (tokens[index]?.type !== "RPAREN") {
-        throw new Error("Unmatched '('");
+        throw new FilterSyntaxError(
+          "Unmatched '('",
+          rangeFor(metadata, index, inputLength),
+        );
       }
       index += 1;
       return node;
     }
 
-    throw new Error("Expected filter term");
+    throw new FilterSyntaxError(
+      "Expected filter term",
+      rangeFor(metadata, index, inputLength),
+    );
   }
 
   const node = parseExpression();
 
   if (index < tokens.length) {
-    throw new Error("Unexpected trailing tokens");
+    throw new FilterSyntaxError(
+      "Unexpected trailing tokens",
+      rangeFor(metadata, index, inputLength),
+    );
   }
 
   return node;
 }
 
-const FIELD_ALIASES: Record<string, string[]> = {
+export type FilterAnalysis = {
+  tokens: FilterTokenWithRange[];
+  ast: FilterNode | null;
+  error: FilterSyntaxError | null;
+};
+
+export function analyzeFilter(expression: string): FilterAnalysis {
+  const trimmed = expression.trim();
+  if (trimmed.length === 0) {
+    return { tokens: [], ast: null, error: null };
+  }
+
+  let detailedTokens: FilterTokenWithRange[] = [];
+
+  try {
+    detailedTokens = tokenizeFilterDetailed(expression);
+  } catch (err) {
+    if (err instanceof FilterSyntaxError) {
+      return {
+        tokens: err.tokens ?? detailedTokens,
+        ast: null,
+        error: err,
+      };
+    }
+
+    return {
+      tokens: [],
+      ast: null,
+      error: new FilterSyntaxError(
+        err instanceof Error ? err.message : "Invalid display filter",
+        { start: expression.length, end: expression.length },
+      ),
+    };
+  }
+
+  if (detailedTokens.length === 0) {
+    return { tokens: detailedTokens, ast: null, error: null };
+  }
+
+  try {
+    const ast = parseFilter(
+      detailedTokens.map(({ start, end, raw, ...token }) => token),
+      { metadata: detailedTokens, inputLength: expression.length },
+    );
+    return { tokens: detailedTokens, ast, error: null };
+  } catch (err) {
+    if (err instanceof FilterSyntaxError) {
+      if (!err.tokens) {
+        err.tokens = detailedTokens;
+      }
+      return { tokens: detailedTokens, ast: null, error: err };
+    }
+
+    return {
+      tokens: detailedTokens,
+      ast: null,
+      error: new FilterSyntaxError(
+        err instanceof Error ? err.message : "Invalid display filter",
+        { start: expression.length, end: expression.length },
+        detailedTokens,
+      ),
+    };
+  }
+}
+
+export const FIELD_ALIASES: Record<string, string[]> = {
   src: ["src", "source"],
   source: ["src", "source"],
   dst: ["dst", "destination"],

--- a/docs/src/storage.ts
+++ b/docs/src/storage.ts
@@ -1,0 +1,91 @@
+const memoryStore = new Map<string, string>();
+
+type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+function getBrowserStorage(): StorageLike {
+  if (typeof window !== "undefined" && window.localStorage) {
+    try {
+      const testKey = "pipe-lion-storage-test";
+      window.localStorage.setItem(testKey, "1");
+      window.localStorage.removeItem(testKey);
+      return window.localStorage;
+    } catch (err) {
+      console.debug("Falling back to in-memory storage", err);
+    }
+  }
+
+  return {
+    getItem: (key) => memoryStore.get(key) ?? null,
+    setItem: (key, value) => {
+      memoryStore.set(key, value);
+    },
+    removeItem: (key) => {
+      memoryStore.delete(key);
+    },
+  };
+}
+
+function normaliseList(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input
+    .map((value) => (typeof value === "string" ? value : null))
+    .filter((value): value is string => value !== null);
+}
+
+export function createStoredList(key: string, limit = 5) {
+  function load(): string[] {
+    const storage = getBrowserStorage();
+    const raw = storage.getItem(key);
+    if (!raw) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      return normaliseList(parsed).slice(0, limit);
+    } catch (err) {
+      console.debug("Failed to parse stored list", err);
+      return [];
+    }
+  }
+
+  function save(values: string[]) {
+    const storage = getBrowserStorage();
+    if (values.length === 0) {
+      storage.removeItem(key);
+      return;
+    }
+
+    storage.setItem(key, JSON.stringify(values.slice(0, limit)));
+  }
+
+  function remember(value: string): string[] {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return load();
+    }
+
+    const existing = load();
+    const deduped = existing.filter((entry) => entry !== trimmed);
+    deduped.unshift(trimmed);
+    const result = deduped.slice(0, limit);
+    save(result);
+    return result;
+  }
+
+  function clear() {
+    const storage = getBrowserStorage();
+    storage.removeItem(key);
+  }
+
+  return { load, save, remember, clear };
+}
+
+export type StoredList = ReturnType<typeof createStoredList>;

--- a/docs/src/test/setup.ts
+++ b/docs/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -10,4 +10,10 @@ const repositoryName = repository?.includes("/")
 export default defineConfig({
   base: repositoryName ? `/${repositoryName}/` : "/",
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+    css: true,
+    environmentMatchGlobs: [["src/wasm.test.ts", "node"]],
+  },
 });


### PR DESCRIPTION
## Summary
- add a FilterInput component that wraps the display filter input with context-aware suggestions, inline validation feedback, and reusable history chips
- extend the filter utilities to surface token metadata, richer syntax errors, and expose storage helpers plus supporting styles/configuration updates
- add testing-library based UI coverage for the filter assistant and configure Vitest to run under jsdom where appropriate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de9fb305a08328b304a74dd807490b