### PR TITLE
Persist display filter and file size preferences

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -354,11 +354,7 @@ function App() {
 
   const applyMaxFileSize = useCallback(
     (value: number, { persist = true }: { persist?: boolean } = {}) => {
-      const clampedValue = clamp(
-        value,
-        MIN_FILE_SIZE_MB,
-        MAX_FILE_SIZE_MB,
-      );
+      const clampedValue = clamp(value, MIN_FILE_SIZE_MB, MAX_FILE_SIZE_MB);
       setMaxFileSizeMB(clampedValue);
       if (persist) {
         saveMaxFileSizeMB(clampedValue);

--- a/docs/src/storage.ts
+++ b/docs/src/storage.ts
@@ -1,0 +1,69 @@
+const MAX_FILE_SIZE_KEY = "pipe-lion:max-file-size-mb";
+const FILTER_TEXT_KEY = "pipe-lion:filter-text";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function getLocalStorage(): StorageLike | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch (err) {
+    console.warn("Unable to access localStorage", err);
+    return null;
+  }
+}
+
+export function loadMaxFileSizeMB(): number | null {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return null;
+  }
+
+  const value = storage.getItem(MAX_FILE_SIZE_KEY);
+  if (value === null) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function saveMaxFileSizeMB(value: number | null): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  if (value === null) {
+    storage.removeItem(MAX_FILE_SIZE_KEY);
+    return;
+  }
+
+  storage.setItem(MAX_FILE_SIZE_KEY, String(value));
+}
+
+export function loadFilterText(): string | null {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return null;
+  }
+
+  return storage.getItem(FILTER_TEXT_KEY);
+}
+
+export function saveFilterText(value: string | null): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  if (value === null) {
+    storage.removeItem(FILTER_TEXT_KEY);
+    return;
+  }
+
+  storage.setItem(FILTER_TEXT_KEY, value);
+}


### PR DESCRIPTION
## Summary
- add a storage helper that safely interacts with localStorage for saved preferences
- initialize the display filter and max file size from storage and persist updates when they change
- update the toolbar hint to mention that preferences live in the browser

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de9fb227b8832893de245b95f44beb