### PR TITLE
Add packet export helper with format selection

### DIFF
--- a/docs/src/App.css
+++ b/docs/src/App.css
@@ -137,6 +137,31 @@
   gap: 0.6rem;
 }
 
+.toolbar-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: rgba(191, 219, 254, 0.85);
+}
+
+.toolbar-select select {
+  background: #0b1730;
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  min-width: 7rem;
+}
+
+.toolbar-select select:disabled {
+  background: #111827;
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(148, 163, 184, 0.55);
+}
+
 .toolbar-buttons button,
 .drop-overlay button {
   background: linear-gradient(180deg, #1d4ed8 0%, #1e3a8a 100%);

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -7,10 +7,7 @@ import {
   type FilterNode,
   type PacketRecord as FilterPacketRecord,
 } from "./filter";
-import {
-  downloadPacketExport,
-  type PacketExportFormat,
-} from "./exporter";
+import { downloadPacketExport, type PacketExportFormat } from "./exporter";
 import { parsePacketSummaryLine } from "./summary";
 import { loadProcessor, type PacketRecord as WasmPacketRecord } from "./wasm";
 
@@ -359,7 +356,9 @@ function App() {
         prev && prev.toLowerCase().includes("export") ? null : prev,
       );
       setStatus(
-        `Exported ${packets.length} ${label} as ${result.format.toUpperCase()}.`,
+        `Exported ${
+          packets.length
+        } ${label} as ${result.format.toUpperCase()}.`,
       );
     } catch (err) {
       console.error("Packet export failed", err);

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -7,6 +7,10 @@ import {
   type FilterNode,
   type PacketRecord as FilterPacketRecord,
 } from "./filter";
+import {
+  downloadPacketExport,
+  type PacketExportFormat,
+} from "./exporter";
 import { parsePacketSummaryLine } from "./summary";
 import { loadProcessor, type PacketRecord as WasmPacketRecord } from "./wasm";
 
@@ -103,6 +107,7 @@ function App() {
   const [filterText, setFilterText] = useState("");
   const [filterAst, setFilterAst] = useState<FilterNode | null>(null);
   const [filterError, setFilterError] = useState<string | null>(null);
+  const [exportFormat, setExportFormat] = useState<PacketExportFormat>("json");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const processingQueueRef = useRef<Promise<void>>(Promise.resolve());
   const uploadTokenRef = useRef(0);
@@ -329,6 +334,42 @@ function App() {
     }
     setDragActive(false);
   }, []);
+
+  const onExportFormatChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setExportFormat(event.target.value as PacketExportFormat);
+    },
+    [],
+  );
+
+  const onSaveClick = useCallback(() => {
+    if (!isReady) {
+      return;
+    }
+
+    if (packets.length === 0) {
+      setError("No packets are available to export yet.");
+      return;
+    }
+
+    try {
+      const result = downloadPacketExport(packets, { format: exportFormat });
+      const label = packets.length === 1 ? "packet" : "packets";
+      setError((prev) =>
+        prev && prev.toLowerCase().includes("export") ? null : prev,
+      );
+      setStatus(
+        `Exported ${packets.length} ${label} as ${result.format.toUpperCase()}.`,
+      );
+    } catch (err) {
+      console.error("Packet export failed", err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Failed to export the current packet list.";
+      setError(message);
+    }
+  }, [exportFormat, isReady, packets]);
 
   const onFileChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -619,9 +660,26 @@ function App() {
             <button type="button" onClick={onBrowseClick} disabled={!isReady}>
               Open Capture…
             </button>
-            <button type="button" disabled>
+            <button
+              type="button"
+              onClick={onSaveClick}
+              disabled={!isReady}
+              aria-disabled={!isReady ? true : undefined}
+            >
               Save As…
             </button>
+            <label className="toolbar-select" htmlFor="export-format">
+              <span>Format</span>
+              <select
+                id="export-format"
+                value={exportFormat}
+                onChange={onExportFormatChange}
+                disabled={!isReady}
+              >
+                <option value="json">JSON</option>
+                <option value="pcap">PCAP</option>
+              </select>
+            </label>
             <button type="button" disabled>
               Restart Capture
             </button>

--- a/docs/src/exporter.test.ts
+++ b/docs/src/exporter.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { createPacketExport } from "./exporter";
 import type { PacketRecord } from "./wasm";
 
-const createSamplePacket = (overrides: Partial<PacketRecord> = {}): PacketRecord => ({
+const createSamplePacket = (
+  overrides: Partial<PacketRecord> = {},
+): PacketRecord => ({
   time: "1.234567",
   source: "192.168.0.1",
   destination: "192.168.0.2",
@@ -16,7 +18,9 @@ const createSamplePacket = (overrides: Partial<PacketRecord> = {}): PacketRecord
 
 describe("createPacketExport", () => {
   it("throws when no packets are provided", () => {
-    expect(() => createPacketExport([])).toThrow("No packets available to export.");
+    expect(() => createPacketExport([])).toThrow(
+      "No packets available to export.",
+    );
   });
 
   it("creates a JSON blob with base64 payloads", async () => {

--- a/docs/src/exporter.test.ts
+++ b/docs/src/exporter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { createPacketExport } from "./exporter";
+import type { PacketRecord } from "./wasm";
+
+const createSamplePacket = (overrides: Partial<PacketRecord> = {}): PacketRecord => ({
+  time: "1.234567",
+  source: "192.168.0.1",
+  destination: "192.168.0.2",
+  protocol: "TCP",
+  length: 3,
+  info: "Test packet",
+  payload: new Uint8Array([0xde, 0xad, 0xbe]),
+  ...overrides,
+});
+
+describe("createPacketExport", () => {
+  it("throws when no packets are provided", () => {
+    expect(() => createPacketExport([])).toThrow("No packets available to export.");
+  });
+
+  it("creates a JSON blob with base64 payloads", async () => {
+    const { blob, format, filename } = createPacketExport([
+      createSamplePacket(),
+    ]);
+
+    expect(format).toBe("json");
+    expect(blob.type).toBe("application/json");
+    expect(filename.endsWith(".json")).toBe(true);
+
+    const text = await blob.text();
+    const parsed = JSON.parse(text) as {
+      packetCount: number;
+      packets: Array<{ payload: string; payloadLength: number }>;
+    };
+
+    expect(parsed.packetCount).toBe(1);
+    expect(parsed.packets).toHaveLength(1);
+    expect(parsed.packets[0]?.payload).toBe("3q2+");
+    expect(parsed.packets[0]?.payloadLength).toBe(3);
+  });
+
+  it("creates a PCAP blob with the correct structure", async () => {
+    const packet = createSamplePacket({ time: "2.000001" });
+    const { blob, format, filename } = createPacketExport([packet], {
+      format: "pcap",
+    });
+
+    expect(format).toBe("pcap");
+    expect(blob.type).toBe("application/vnd.tcpdump.pcap");
+    expect(filename.endsWith(".pcap")).toBe(true);
+
+    const buffer = await blob.arrayBuffer();
+    const view = new DataView(buffer);
+
+    expect(view.getUint32(0, true)).toBe(0xa1b2c3d4);
+    expect(view.getUint16(4, true)).toBe(2);
+    expect(view.getUint16(6, true)).toBe(4);
+
+    const tsSeconds = view.getUint32(24, true);
+    const tsMicros = view.getUint32(28, true);
+    const includedLength = view.getUint32(32, true);
+    const originalLength = view.getUint32(36, true);
+
+    expect(tsSeconds).toBe(2);
+    expect(tsMicros).toBe(1);
+    expect(includedLength).toBe(packet.payload.length);
+    expect(originalLength).toBeGreaterThanOrEqual(packet.payload.length);
+
+    const payload = new Uint8Array(buffer, 40, packet.payload.length);
+    expect(Array.from(payload)).toEqual(Array.from(packet.payload));
+  });
+});

--- a/docs/src/exporter.ts
+++ b/docs/src/exporter.ts
@@ -1,0 +1,246 @@
+import type { PacketRecord } from "./wasm";
+
+export type PacketExportFormat = "json" | "pcap";
+
+export interface PacketExportOptions {
+  format?: PacketExportFormat;
+  filenamePrefix?: string;
+}
+
+export interface PacketExportResult {
+  blob: Blob;
+  filename: string;
+  format: PacketExportFormat;
+}
+
+const JSON_MIME_TYPE = "application/json";
+const PCAP_MIME_TYPE = "application/vnd.tcpdump.pcap";
+const DEFAULT_PREFIX = "packet-export";
+const SNAP_LENGTH = 262_144;
+const LINKTYPE_ETHERNET = 1;
+
+const toBase64 = (bytes: Uint8Array): string => {
+  if (typeof globalThis.btoa === "function") {
+    let binary = "";
+    for (const byte of bytes) {
+      binary += String.fromCharCode(byte);
+    }
+    return globalThis.btoa(binary);
+  }
+
+  const bufferCtor = (globalThis as {
+    Buffer?: {
+      from: (input: Uint8Array | number[], encoding?: string) => {
+        toString: (encoding: string) => string;
+      };
+    };
+  }).Buffer;
+
+  if (bufferCtor) {
+    return bufferCtor.from(bytes).toString("base64");
+  }
+
+  const table =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let output = "";
+  for (let index = 0; index < bytes.length; index += 3) {
+    const chunkLength = Math.min(3, bytes.length - index);
+    const a = bytes[index] ?? 0;
+    const b = bytes[index + 1] ?? 0;
+    const c = bytes[index + 2] ?? 0;
+    const triplet = (a << 16) | (b << 8) | c;
+
+    const enc1 = (triplet >> 18) & 0x3f;
+    const enc2 = (triplet >> 12) & 0x3f;
+    const enc3 = (triplet >> 6) & 0x3f;
+    const enc4 = triplet & 0x3f;
+
+    output += table[enc1] ?? "";
+    output += table[enc2] ?? "";
+    output += chunkLength > 1 ? table[enc3] ?? "" : "=";
+    output += chunkLength > 2 ? table[enc4] ?? "" : "=";
+  }
+
+  return output;
+};
+
+const createJsonExport = (
+  packets: PacketRecord[],
+  filenamePrefix: string,
+): PacketExportResult => {
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    packetCount: packets.length,
+    packets: packets.map((packet, index) => ({
+      index,
+      time: packet.time,
+      source: packet.source,
+      destination: packet.destination,
+      protocol: packet.protocol,
+      length: packet.length,
+      info: packet.info,
+      payloadLength: packet.payload.length,
+      payload: toBase64(packet.payload),
+    })),
+  };
+
+  const content = JSON.stringify(payload, null, 2);
+  const timestamp = new Date().toISOString().replace(/[:]/g, "-");
+  const filename = `${filenamePrefix}-${timestamp}.json`;
+
+  return {
+    blob: new Blob([content], { type: JSON_MIME_TYPE }),
+    filename,
+    format: "json",
+  };
+};
+
+const parseTimestamp = (time: string, fallbackIndex: number): {
+  seconds: number;
+  microseconds: number;
+} => {
+  const numeric = Number(time);
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    const seconds = Math.floor(numeric);
+    const microseconds = Math.round((numeric - seconds) * 1_000_000);
+    return { seconds, microseconds };
+  }
+
+  const match = /^\s*(\d+)(?:\.(\d{1,6}))?\s*$/.exec(time);
+  if (match) {
+    const seconds = Number.parseInt(match[1] ?? "0", 10);
+    const fraction = match[2] ?? "";
+    const microseconds = Number.parseInt(`${fraction.padEnd(6, "0")}`, 10) || 0;
+    return { seconds, microseconds };
+  }
+
+  return { seconds: fallbackIndex, microseconds: 0 };
+};
+
+const createPcapExport = (
+  packets: PacketRecord[],
+  filenamePrefix: string,
+): PacketExportResult => {
+  const headerLength = 24;
+  const recordHeaderLength = 16;
+  const totalLength = packets.reduce(
+    (sum, packet) => sum + recordHeaderLength + packet.payload.length,
+    headerLength,
+  );
+
+  const buffer = new ArrayBuffer(totalLength);
+  const view = new DataView(buffer);
+  let offset = 0;
+
+  view.setUint32(offset, 0xa1b2c3d4, true);
+  offset += 4;
+  view.setUint16(offset, 2, true);
+  offset += 2;
+  view.setUint16(offset, 4, true);
+  offset += 2;
+  view.setInt32(offset, 0, true);
+  offset += 4;
+  view.setUint32(offset, 0, true);
+  offset += 4;
+  view.setUint32(offset, SNAP_LENGTH, true);
+  offset += 4;
+  view.setUint32(offset, LINKTYPE_ETHERNET, true);
+  offset += 4;
+
+  const bufferView = new Uint8Array(buffer);
+
+  packets.forEach((packet, index) => {
+    const { seconds, microseconds } = parseTimestamp(packet.time, index);
+    const payload = packet.payload;
+    const capturedLength = payload.length;
+    const reportedLength = Number.isFinite(packet.length)
+      ? Math.max(packet.length, capturedLength)
+      : capturedLength;
+
+    view.setUint32(offset, seconds, true);
+    offset += 4;
+    view.setUint32(offset, microseconds, true);
+    offset += 4;
+    view.setUint32(offset, capturedLength, true);
+    offset += 4;
+    view.setUint32(offset, reportedLength, true);
+    offset += 4;
+
+    bufferView.set(payload, offset);
+    offset += capturedLength;
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:]/g, "-");
+  const filename = `${filenamePrefix}-${timestamp}.pcap`;
+
+  return {
+    blob: new Blob([buffer], { type: PCAP_MIME_TYPE }),
+    filename,
+    format: "pcap",
+  };
+};
+
+export const createPacketExport = (
+  packets: PacketRecord[],
+  options: PacketExportOptions = {},
+): PacketExportResult => {
+  const { format = "json", filenamePrefix = DEFAULT_PREFIX } = options;
+
+  if (!Array.isArray(packets) || packets.length === 0) {
+    throw new Error("No packets available to export.");
+  }
+
+  switch (format) {
+    case "json":
+      return createJsonExport(packets, filenamePrefix);
+    case "pcap":
+      return createPcapExport(packets, filenamePrefix);
+    default:
+      throw new Error(`Unsupported export format: ${String(format)}`);
+  }
+};
+
+export const downloadPacketExport = (
+  packets: PacketRecord[],
+  options: PacketExportOptions = {},
+): PacketExportResult => {
+  if (typeof document === "undefined" || typeof URL === "undefined") {
+    throw new Error("Packet exports require a browser environment.");
+  }
+
+  const result = createPacketExport(packets, options);
+
+  if (!document.body) {
+    throw new Error("Unable to access the current document body for download.");
+  }
+
+  const urlApi = URL as typeof URL & {
+    createObjectURL?: (obj: Blob) => string;
+    revokeObjectURL?: (url: string) => void;
+  };
+
+  if (
+    typeof urlApi.createObjectURL !== "function" ||
+    typeof urlApi.revokeObjectURL !== "function"
+  ) {
+    throw new Error("The current browser does not support Blob downloads.");
+  }
+
+  const url = urlApi.createObjectURL(result.blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = result.filename;
+  anchor.rel = "noopener";
+  anchor.style.position = "absolute";
+  anchor.style.left = "-9999px";
+
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+
+  setTimeout(() => {
+    urlApi.revokeObjectURL(url);
+  }, 0);
+
+  return result;
+};

--- a/docs/src/exporter.ts
+++ b/docs/src/exporter.ts
@@ -28,13 +28,18 @@ const toBase64 = (bytes: Uint8Array): string => {
     return globalThis.btoa(binary);
   }
 
-  const bufferCtor = (globalThis as {
-    Buffer?: {
-      from: (input: Uint8Array | number[], encoding?: string) => {
-        toString: (encoding: string) => string;
+  const bufferCtor = (
+    globalThis as {
+      Buffer?: {
+        from: (
+          input: Uint8Array | number[],
+          encoding?: string,
+        ) => {
+          toString: (encoding: string) => string;
+        };
       };
-    };
-  }).Buffer;
+    }
+  ).Buffer;
 
   if (bufferCtor) {
     return bufferCtor.from(bytes).toString("base64");
@@ -95,7 +100,10 @@ const createJsonExport = (
   };
 };
 
-const parseTimestamp = (time: string, fallbackIndex: number): {
+const parseTimestamp = (
+  time: string,
+  fallbackIndex: number,
+): {
   seconds: number;
   microseconds: number;
 } => {


### PR DESCRIPTION
## Summary
- add an exporter utility that builds JSON and PCAP artifacts from packet data and initiates downloads
- connect the Save As control to the exporter with format selection, status messaging, and toolbar styling updates
- cover the exporter with new unit tests verifying the generated blobs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68de9fb14bf48328b95b47ad3afec36e