### PR TITLE
Add stored list helper with in-memory fallback

### DIFF
--- a/docs/src/storage.ts
+++ b/docs/src/storage.ts
@@ -16,6 +16,106 @@ function getLocalStorage(): StorageLike | null {
   }
 }
 
+type StoredList = {
+  load: () => string[];
+  remember: (value: string) => string[];
+  clear: () => void;
+};
+
+function sanitizeValues(values: unknown, limit: number): string[] {
+  if (!Array.isArray(values) || limit <= 0) {
+    return [];
+  }
+
+  const result: string[] = [];
+  for (const value of values) {
+    if (typeof value === "string") {
+      result.push(value);
+    }
+
+    if (result.length >= limit) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+export function createStoredList(key: string, limit: number): StoredList {
+  const storage = getLocalStorage();
+  let memoryList: string[] = [];
+
+  function load(): string[] {
+    if (!storage) {
+      return [...memoryList.slice(0, Math.max(0, limit))];
+    }
+
+    const raw = storage.getItem(key);
+    if (raw === null) {
+      memoryList = [];
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      const sanitized = sanitizeValues(parsed, limit);
+      memoryList = sanitized;
+      return [...sanitized];
+    } catch (err) {
+      console.warn("Failed to parse stored list", err);
+      memoryList = [];
+      try {
+        storage.removeItem(key);
+      } catch (removeErr) {
+        console.warn("Failed to reset stored list after parse error", removeErr);
+      }
+      return [];
+    }
+  }
+
+  function remember(value: string): string[] {
+    if (limit <= 0) {
+      memoryList = [];
+      if (storage) {
+        try {
+          storage.removeItem(key);
+        } catch (err) {
+          console.warn("Failed to clear stored list with non-positive limit", err);
+        }
+      }
+      return [];
+    }
+
+    const existing = load();
+    const deduped = existing.filter((item) => item !== value);
+    const updated = [value, ...deduped].slice(0, limit);
+
+    memoryList = updated;
+    if (storage) {
+      try {
+        storage.setItem(key, JSON.stringify(updated));
+      } catch (err) {
+        console.warn("Failed to persist stored list", err);
+      }
+    }
+
+    return [...updated];
+  }
+
+  function clear(): void {
+    memoryList = [];
+    if (storage) {
+      try {
+        storage.removeItem(key);
+      } catch (err) {
+        console.warn("Failed to clear stored list", err);
+      }
+    }
+  }
+
+  return { load, remember, clear };
+}
+
 export function loadMaxFileSizeMB(): number | null {
   const storage = getLocalStorage();
   if (!storage) {


### PR DESCRIPTION
## Summary
- add a `createStoredList` factory for managing string histories with storage fallback
- sanitize and deduplicate stored entries while keeping an in-memory copy for environments without `localStorage`

## Testing
- npm test -- FilterInput

------
https://chatgpt.com/codex/tasks/task_e_68deea9337408328afa7555ff425f383