### PR TITLE
Unify canonical packet field naming in docs packet pipeline

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -9,7 +9,6 @@ import {
 } from "./filter";
 import { downloadPacketExport, type PacketExportFormat } from "./exporter";
 import FilterInput, { type FilterChangeDetails } from "./FilterInput";
-import { parsePacketSummaryLine } from "./summary";
 import { loadProcessor, type PacketRecord as WasmPacketRecord } from "./wasm";
 import {
   loadFilterText,
@@ -77,17 +76,14 @@ function clamp(value: number, min: number, max: number) {
 }
 
 function toFilterPacketRecord(packet: WasmPacketRecord): FilterPacketRecord {
-  const summaryRecord = parsePacketSummaryLine(packet.info);
-
   return {
-    ...summaryRecord,
-    time: summaryRecord.time ?? packet.time,
-    src: summaryRecord.src ?? packet.source,
-    dst: summaryRecord.dst ?? packet.destination,
-    protocol: summaryRecord.protocol ?? packet.protocol,
-    length: summaryRecord.length ?? packet.length,
-    info: summaryRecord.info ?? packet.info,
-    summary: summaryRecord.summary ?? summaryRecord.info,
+    time: packet.time,
+    source: packet.source,
+    destination: packet.destination,
+    protocol: packet.protocol,
+    length: packet.length,
+    info: packet.info,
+    summary: packet.info,
   };
 }
 
@@ -537,8 +533,8 @@ function App() {
         const record = toFilterPacketRecord(packet);
         const searchableText = [
           record.time,
-          record.src,
-          record.dst,
+          record.source,
+          record.destination,
           record.protocol,
           record.length,
           record.info,
@@ -626,10 +622,8 @@ function App() {
 
     return [
       `Time: ${displayedPacket.time ?? "—"}`,
-      `Source: ${displayedPacket.source ?? displayedPacket.src ?? "—"}`,
-      `Destination: ${
-        displayedPacket.destination ?? displayedPacket.dst ?? "—"
-      }`,
+      `Source: ${displayedPacket.source ?? "—"}`,
+      `Destination: ${displayedPacket.destination ?? "—"}`,
       `Protocol: ${displayedPacket.protocol ?? "—"}`,
       `Length: ${
         displayedPacket.length !== undefined

--- a/docs/src/filter.ts
+++ b/docs/src/filter.ts
@@ -1,8 +1,6 @@
 export type PacketRecord = {
   time?: string;
-  src?: string;
   source?: string;
-  dst?: string;
   destination?: string;
   protocol?: string;
   length?: string | number;
@@ -10,6 +8,11 @@ export type PacketRecord = {
   summary?: string;
   payload?: Uint8Array;
   [key: string]: string | number | Uint8Array | undefined;
+};
+
+export type LegacyPacketAddressAliases = {
+  src?: string;
+  dst?: string;
 };
 
 export type FilterNode =
@@ -488,9 +491,15 @@ function resolveFieldValue(
   packet: PacketRecord,
   field: string,
 ): string | number | undefined {
+  const legacyPacket = packet as PacketRecord & LegacyPacketAddressAliases;
   const candidates = FIELD_ALIASES[field] ?? [field];
   for (const candidate of candidates) {
-    const value = packet[candidate];
+    const value =
+      candidate === "src"
+        ? legacyPacket.src
+        : candidate === "dst"
+          ? legacyPacket.dst
+          : packet[candidate];
     if (value === undefined) {
       continue;
     }

--- a/docs/src/wasm.ts
+++ b/docs/src/wasm.ts
@@ -207,17 +207,26 @@ const parseProcessingResult = (
             const legacySource =
               record.source ?? record.src ?? record.Source ?? record.Src;
             const legacyDestination =
-              record.destination ?? record.dst ?? record.Destination ?? record.Dst;
+              record.destination ??
+              record.dst ??
+              record.Destination ??
+              record.Dst;
 
             return {
               time: toStringOrFallback(record.time, "0.000000"),
               source: toStringOrFallback(legacySource, "—"),
               destination: toStringOrFallback(legacyDestination, "—"),
-              protocol: toStringOrFallback(record.protocol ?? record.proto, "—"),
+              protocol: toStringOrFallback(
+                record.protocol ?? record.proto,
+                "—",
+              ),
               length: Math.max(
                 0,
                 Math.round(
-                  toFiniteNumberOrFallback(record.length ?? record.len ?? record.size, fallbackLength),
+                  toFiniteNumberOrFallback(
+                    record.length ?? record.len ?? record.size,
+                    fallbackLength,
+                  ),
                 ),
               ),
               info: toStringOrFallback(record.info ?? record.summary, "—"),

--- a/docs/src/wasm.ts
+++ b/docs/src/wasm.ts
@@ -203,18 +203,24 @@ const parseProcessingResult = (
             const fallbackLength =
               payload.length > 0 ? payload.length : bytes.length;
 
+            // TODO(2026-12-31): Remove legacy src/dst fallback after all clients emit canonical source/destination fields.
+            const legacySource =
+              record.source ?? record.src ?? record.Source ?? record.Src;
+            const legacyDestination =
+              record.destination ?? record.dst ?? record.Destination ?? record.Dst;
+
             return {
               time: toStringOrFallback(record.time, "0.000000"),
-              source: toStringOrFallback(record.source, "—"),
-              destination: toStringOrFallback(record.destination, "—"),
-              protocol: toStringOrFallback(record.protocol, "—"),
+              source: toStringOrFallback(legacySource, "—"),
+              destination: toStringOrFallback(legacyDestination, "—"),
+              protocol: toStringOrFallback(record.protocol ?? record.proto, "—"),
               length: Math.max(
                 0,
                 Math.round(
-                  toFiniteNumberOrFallback(record.length, fallbackLength),
+                  toFiniteNumberOrFallback(record.length ?? record.len ?? record.size, fallbackLength),
                 ),
               ),
-              info: toStringOrFallback(record.info, "—"),
+              info: toStringOrFallback(record.info ?? record.summary, "—"),
               payload,
             };
           })


### PR DESCRIPTION
### Motivation
- Standardize packet field names used by the docs-side processing/UI to match canonical names (`time`, `source`, `destination`, `protocol`, `length`, `info`, `payload`).
- Remove redundant summary-line reparsing in the App when Wasm already emits canonical fields to simplify mapping and avoid duplicate logic.
- Keep compatibility for older toolchains that still emit legacy aliases (`src`/`dst`, `proto`, `len`/`size`, `summary`) while moving toward a single canonical shape.
- Provide a clear migration fallback with an explicit removal criterion to allow phased rollout.

### Description
- `docs/src/wasm.ts`: added a migration fallback in `parseProcessingResult` that prefers canonical `source`/`destination` but falls back to `src`/`dst` (and supports `proto`, `len`/`size`, and `summary`), and included a dated TODO removal marker (`2026-12-31`).
- `docs/src/filter.ts`: simplified `PacketRecord` to only declare canonical fields, added `LegacyPacketAddressAliases` to isolate legacy `src`/`dst`, and updated `resolveFieldValue` to consult the legacy aliases only inside the field resolver.
- `docs/src/App.tsx`: removed `parsePacketSummaryLine` usage and the summary-line reparsing path in `toFilterPacketRecord`, now consuming canonical Wasm packet fields directly and updating searchable text/detail rendering to use `source`/`destination`.
- Minor robustness updates: `parseProcessingResult` now also accepts numeric-length strings via `len`/`size` fallbacks and prefers `summary` when `info` is absent.

### Testing
- Ran the docs test suite from `docs/`: `npm test -- --run src/filter.test.ts src/wasm.test.ts src/summary.test.ts src/App.test.tsx`; `filter`, `wasm`, and `summary` suites passed while `App.test.tsx` failed due to an existing test asserting a single "Restart Capture" button when two matching buttons exist in the test DOM.
- Attempted to run tests from repo root but that run failed because a `package.json` is not present at the repository root, so repository-root test invocation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65a1966708328805377edb993b810)