### PR TITLE
Add dedicated diagnostics panel for processing warnings and errors

### DIFF
--- a/docs/src/App.css
+++ b/docs/src/App.css
@@ -607,3 +607,16 @@
     grid-template-rows: repeat(3, minmax(200px, auto));
   }
 }
+
+.diagnostics-block h3 {
+  margin: 0.25rem 0;
+  font-size: 0.95rem;
+}
+
+.diagnostics-errors h3 {
+  color: #fca5a5;
+}
+
+.diagnostics-warnings h3 {
+  color: #fcd34d;
+}

--- a/docs/src/App.test.tsx
+++ b/docs/src/App.test.tsx
@@ -109,9 +109,11 @@ describe("App restart flow", () => {
 
     render(<App />);
 
-    const restartButton = await screen.findByRole("button", {
+    const restartButtons = await screen.findAllByRole("button", {
       name: "Restart Capture",
     });
+    const restartButton = restartButtons.find((button) => !button.hasAttribute("disabled"));
+    expect(restartButton).toBeDefined();
     await waitFor(() => expect(restartButton).toBeEnabled());
 
     const statusChip = screen.getByRole("status");
@@ -145,6 +147,7 @@ describe("App restart flow", () => {
     );
 
     const errorBanner = await screen.findByRole("alert");
+    expect(errorBanner).toHaveTextContent("Fatal parse errors");
     expect(errorBanner).toHaveTextContent("Processing issue");
     expect(
       screen.queryByText("Drop a capture to populate the packet list."),
@@ -185,9 +188,11 @@ describe("App restart flow", () => {
 
     render(<App />);
 
-    const restartButton = await screen.findByRole("button", {
+    const restartButtons = await screen.findAllByRole("button", {
       name: "Restart Capture",
     });
+    const restartButton = restartButtons.find((button) => !button.hasAttribute("disabled"));
+    expect(restartButton).toBeDefined();
     await waitFor(() => expect(restartButton).toBeEnabled());
     const statusChip = screen.getByRole("status");
 
@@ -225,5 +230,95 @@ describe("App restart flow", () => {
     expect(
       screen.getByText("Drop a capture to populate the packet list."),
     ).toBeInTheDocument();
+  });
+});
+
+
+
+describe("Diagnostics panel", () => {
+  beforeEach(() => {
+    activeReaders.length = 0;
+    processPacketMock.mockReset();
+    loadProcessorMock.mockReset();
+    loadProcessorMock.mockResolvedValue(mockProcessor);
+    globalThis.FileReader =
+      ControlledFileReader as unknown as typeof FileReader;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders warning-only diagnostics without fatal section", async () => {
+    processPacketMock.mockImplementation(() => ({
+      packets: [],
+      warnings: ["Truncated frame data"],
+      errors: [],
+    }));
+
+    render(<App />);
+
+    const fileInput = document.getElementById("file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File([Uint8Array.from([0x01])], "warn.pcap")],
+      },
+    });
+
+    await waitFor(() => expect(activeReaders.length).toBeGreaterThan(0));
+    await activeReaders[0]?.emitLoad();
+
+    expect(await screen.findByText("⚠️ Non-fatal warnings")).toBeInTheDocument();
+    expect(screen.getByText("Truncated frame data")).toBeInTheDocument();
+    expect(screen.queryByText("⛔ Fatal parse errors")).not.toBeInTheDocument();
+  });
+
+  it("renders error-only diagnostics", async () => {
+    processPacketMock.mockImplementation(() => ({
+      packets: [],
+      warnings: [],
+      errors: ["Unsupported packet format"],
+    }));
+
+    render(<App />);
+
+    const fileInput = document.getElementById("file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File([Uint8Array.from([0x02])], "error.pcap")],
+      },
+    });
+
+    await waitFor(() => expect(activeReaders.length).toBeGreaterThan(0));
+    await activeReaders[0]?.emitLoad();
+
+    expect(await screen.findByText("⛔ Fatal parse errors")).toBeInTheDocument();
+    expect(screen.getByText("Unsupported packet format")).toBeInTheDocument();
+    expect(screen.queryByText("⚠️ Non-fatal warnings")).not.toBeInTheDocument();
+  });
+
+  it("renders both warnings and errors together", async () => {
+    processPacketMock.mockImplementation(() => ({
+      packets: [],
+      warnings: ["Recovered packet boundary"],
+      errors: ["CRC mismatch"],
+    }));
+
+    render(<App />);
+
+    const fileInput = document.getElementById("file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File([Uint8Array.from([0x03])], "mixed.pcap")],
+      },
+    });
+
+    await waitFor(() => expect(activeReaders.length).toBeGreaterThan(0));
+    await activeReaders[0]?.emitLoad();
+
+    expect(await screen.findByText("⛔ Fatal parse errors")).toBeInTheDocument();
+    expect(screen.getByText("CRC mismatch")).toBeInTheDocument();
+    expect(screen.getByText("⚠️ Non-fatal warnings")).toBeInTheDocument();
+    expect(screen.getByText("Recovered packet boundary")).toBeInTheDocument();
   });
 });

--- a/docs/src/App.test.tsx
+++ b/docs/src/App.test.tsx
@@ -112,7 +112,9 @@ describe("App restart flow", () => {
     const restartButtons = await screen.findAllByRole("button", {
       name: "Restart Capture",
     });
-    const restartButton = restartButtons.find((button) => !button.hasAttribute("disabled"));
+    const restartButton = restartButtons.find(
+      (button) => !button.hasAttribute("disabled"),
+    );
     expect(restartButton).toBeDefined();
     await waitFor(() => expect(restartButton).toBeEnabled());
 
@@ -191,7 +193,9 @@ describe("App restart flow", () => {
     const restartButtons = await screen.findAllByRole("button", {
       name: "Restart Capture",
     });
-    const restartButton = restartButtons.find((button) => !button.hasAttribute("disabled"));
+    const restartButton = restartButtons.find(
+      (button) => !button.hasAttribute("disabled"),
+    );
     expect(restartButton).toBeDefined();
     await waitFor(() => expect(restartButton).toBeEnabled());
     const statusChip = screen.getByRole("status");
@@ -233,8 +237,6 @@ describe("App restart flow", () => {
   });
 });
 
-
-
 describe("Diagnostics panel", () => {
   beforeEach(() => {
     activeReaders.length = 0;
@@ -268,7 +270,9 @@ describe("Diagnostics panel", () => {
     await waitFor(() => expect(activeReaders.length).toBeGreaterThan(0));
     await activeReaders[0]?.emitLoad();
 
-    expect(await screen.findByText("⚠️ Non-fatal warnings")).toBeInTheDocument();
+    expect(
+      await screen.findByText("⚠️ Non-fatal warnings"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Truncated frame data")).toBeInTheDocument();
     expect(screen.queryByText("⛔ Fatal parse errors")).not.toBeInTheDocument();
   });
@@ -292,7 +296,9 @@ describe("Diagnostics panel", () => {
     await waitFor(() => expect(activeReaders.length).toBeGreaterThan(0));
     await activeReaders[0]?.emitLoad();
 
-    expect(await screen.findByText("⛔ Fatal parse errors")).toBeInTheDocument();
+    expect(
+      await screen.findByText("⛔ Fatal parse errors"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Unsupported packet format")).toBeInTheDocument();
     expect(screen.queryByText("⚠️ Non-fatal warnings")).not.toBeInTheDocument();
   });
@@ -316,7 +322,9 @@ describe("Diagnostics panel", () => {
     await waitFor(() => expect(activeReaders.length).toBeGreaterThan(0));
     await activeReaders[0]?.emitLoad();
 
-    expect(await screen.findByText("⛔ Fatal parse errors")).toBeInTheDocument();
+    expect(
+      await screen.findByText("⛔ Fatal parse errors"),
+    ).toBeInTheDocument();
     expect(screen.getByText("CRC mismatch")).toBeInTheDocument();
     expect(screen.getByText("⚠️ Non-fatal warnings")).toBeInTheDocument();
     expect(screen.getByText("Recovered packet boundary")).toBeInTheDocument();

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -918,17 +918,24 @@ function App() {
             </div>
           </section>
 
-          <section className="pane diagnostics" aria-label="Processing diagnostics">
+          <section
+            className="pane diagnostics"
+            aria-label="Processing diagnostics"
+          >
             <header>
               <h2>Diagnostics</h2>
               <span className="pane-subtitle">Warnings and parse outcomes</span>
             </header>
-            {processingErrors.length === 0 && processingWarnings.length === 0 ? (
+            {processingErrors.length === 0 &&
+            processingWarnings.length === 0 ? (
               <p>No diagnostics for the latest processed file.</p>
             ) : (
               <>
                 {processingErrors.length > 0 && (
-                  <div className="diagnostics-block diagnostics-errors" role="alert">
+                  <div
+                    className="diagnostics-block diagnostics-errors"
+                    role="alert"
+                  >
                     <h3>⛔ Fatal parse errors</h3>
                     <ul>
                       {processingErrors.map((message, index) => (

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -107,6 +107,8 @@ function App() {
   );
   const [dragActive, setDragActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [processingWarnings, setProcessingWarnings] = useState<string[]>([]);
+  const [processingErrors, setProcessingErrors] = useState<string[]>([]);
   const [isReady, setIsReady] = useState(false);
   const [maxFileSizeMB, setMaxFileSizeMB] = useState(DEFAULT_MAX_FILE_SIZE_MB);
   const [filterText, setFilterText] = useState("");
@@ -136,6 +138,8 @@ function App() {
     setStatus(DEFAULT_STATUS_MESSAGE);
     setError(null);
     setDragActive(false);
+    setProcessingWarnings([]);
+    setProcessingErrors([]);
   }, [abortActiveReader]);
 
   const readFileBytes = useCallback(
@@ -275,13 +279,10 @@ function App() {
         if (!isMountedRef.current) {
           return;
         }
-        if (result.errors.length > 0) {
-          setError(result.errors.join(" \u2022 "));
-        } else if (result.warnings.length > 0) {
-          setError(result.warnings.join(" \u2022 "));
-        } else {
-          setError(null);
-        }
+        setProcessingErrors(Array.isArray(result.errors) ? result.errors : []);
+        setProcessingWarnings(
+          Array.isArray(result.warnings) ? result.warnings : [],
+        );
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
           return;
@@ -294,6 +295,8 @@ function App() {
           return;
         }
         setError("Failed to process the uploaded file.");
+        setProcessingErrors([]);
+        setProcessingWarnings([]);
 
         if (!isMountedRef.current) {
           return;
@@ -913,6 +916,39 @@ function App() {
                 </div>
               )}
             </div>
+          </section>
+
+          <section className="pane diagnostics" aria-label="Processing diagnostics">
+            <header>
+              <h2>Diagnostics</h2>
+              <span className="pane-subtitle">Warnings and parse outcomes</span>
+            </header>
+            {processingErrors.length === 0 && processingWarnings.length === 0 ? (
+              <p>No diagnostics for the latest processed file.</p>
+            ) : (
+              <>
+                {processingErrors.length > 0 && (
+                  <div className="diagnostics-block diagnostics-errors" role="alert">
+                    <h3>⛔ Fatal parse errors</h3>
+                    <ul>
+                      {processingErrors.map((message, index) => (
+                        <li key={`processing-error-${index}`}>{message}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {processingWarnings.length > 0 && (
+                  <div className="diagnostics-block diagnostics-warnings">
+                    <h3>⚠️ Non-fatal warnings</h3>
+                    <ul>
+                      {processingWarnings.map((message, index) => (
+                        <li key={`processing-warning-${index}`}>{message}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            )}
           </section>
 
           <section className="pane packet-details" aria-label="Packet details">


### PR DESCRIPTION
### Motivation
- Surface packet-processing diagnostics (warnings/errors) as structured UI output instead of a collapsed toolbar string to improve visibility and troubleshooting.
- Treat fatal parse errors and non-fatal warnings as first-class, distinct items so users can quickly distinguish severity.
- Preserve lifecycle status messages while preventing routine status updates from clobbering the most recent diagnostics.

### Description
- Track diagnostics with two React state arrays `processingWarnings` and `processingErrors` and clear them on restart or hard failures (`docs/src/App.tsx`).
- Populate these arrays from `result.warnings` and `result.errors` returned by the processor instead of joining them into the `error` string, and clear them on processing exceptions (`docs/src/App.tsx`).
- Render a new dedicated "Diagnostics" pane adjacent to packet list/details that shows a fatal-errors block (with a distinct heading/icon and `role="alert"`) and a non-fatal-warnings block, each listing individual messages (`docs/src/App.tsx`).
- Add minimal styling to visually differentiate error and warning headings (`docs/src/App.css`).
- Extend and adjust component tests: added tests for warning-only, error-only, and mixed diagnostics; and changed restart-button lookup logic to handle duplicate-labeled buttons in the toolbar (`docs/src/App.test.tsx`).

### Testing
- Ran the component test suite with `cd docs && npm test -- --run App.test.tsx` and all tests passed (5 tests total).
- Verified the restart/workspace tests and the new diagnostics tests for warning-only, error-only, and mixed outputs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65a1c661483289a2d82a06eb7cbc5)