### PR TITLE
Handle preference persistence failures non-blockingly

### DIFF
--- a/docs/src/App.test.tsx
+++ b/docs/src/App.test.tsx
@@ -16,6 +16,7 @@ import {
   vi,
 } from "vitest";
 import App from "./App";
+import * as storage from "./storage";
 
 const { processPacketMock, loadProcessorMock } = vi.hoisted(() => ({
   processPacketMock: vi.fn(),
@@ -234,6 +235,19 @@ describe("App restart flow", () => {
     expect(
       screen.getByText("Drop a capture to populate the packet list."),
     ).toBeInTheDocument();
+  });
+
+  it("shows non-blocking hint when preference persistence fails", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(storage, "saveFilterText").mockReturnValue(false);
+
+    render(<App />);
+
+    const filterInput = await screen.findByLabelText("Display filter");
+    await user.type(filterInput, "tcp");
+
+    expect(await screen.findByText("Preferences not persisted.")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -111,6 +111,7 @@ function App() {
   const [filterAst, setFilterAst] = useState<FilterNode | null>(null);
   const [filterError, setFilterError] = useState<string | null>(null);
   const [exportFormat, setExportFormat] = useState<PacketExportFormat>("json");
+  const [preferencesPersistError, setPreferencesPersistError] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const processingQueueRef = useRef<Promise<void>>(Promise.resolve());
   const uploadTokenRef = useRef(0);
@@ -415,7 +416,8 @@ function App() {
       const clampedValue = clamp(value, MIN_FILE_SIZE_MB, MAX_FILE_SIZE_MB);
       setMaxFileSizeMB(clampedValue);
       if (persist) {
-        saveMaxFileSizeMB(clampedValue);
+        const saved = saveMaxFileSizeMB(clampedValue);
+        setPreferencesPersistError((prev) => prev || !saved);
       }
       return clampedValue;
     },
@@ -434,11 +436,13 @@ function App() {
 
       const trimmed = value.trim();
       if (persist) {
+        let saved = true;
         if (trimmed.length === 0) {
-          saveFilterText(null);
+          saved = saveFilterText(null);
         } else {
-          saveFilterText(value);
+          saved = saveFilterText(value);
         }
+        setPreferencesPersistError((prev) => prev || !saved);
       }
 
       if (trimmed.length === 0) {
@@ -485,7 +489,8 @@ function App() {
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const rawValue = event.target.value;
       if (rawValue === "") {
-        saveMaxFileSizeMB(null);
+        const saved = saveMaxFileSizeMB(null);
+        setPreferencesPersistError((prev) => prev || !saved);
         applyMaxFileSize(DEFAULT_MAX_FILE_SIZE_MB, { persist: false });
         return;
       }
@@ -779,6 +784,8 @@ function App() {
             <div className="toolbar-error" role="alert" aria-live="assertive">
               {error}
             </div>
+          ) : preferencesPersistError ? (
+            <div className="toolbar-hint">Preferences not persisted.</div>
           ) : (
             <div className="toolbar-hint">
               Filter and size preferences are stored in this browser.

--- a/docs/src/storage.test.tsx
+++ b/docs/src/storage.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createStoredList,
+  saveFilterText,
+  saveMaxFileSizeMB,
+} from "./storage";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("storage persistence", () => {
+  it("returns false when localStorage is unavailable", () => {
+    vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    expect(saveMaxFileSizeMB(25)).toBe(false);
+    expect(saveFilterText("tcp")).toBe(false);
+  });
+
+  it("returns false when max file size write fails", () => {
+    const setItemMock = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+    expect(saveMaxFileSizeMB(42)).toBe(false);
+    expect(setItemMock).toHaveBeenCalled();
+  });
+
+  it("returns false when filter text removal fails", () => {
+    const removeItemMock = vi
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(() => {
+        throw new Error("remove failed");
+      });
+
+    expect(saveFilterText(null)).toBe(false);
+    expect(removeItemMock).toHaveBeenCalled();
+  });
+});
+
+describe("createStoredList parse reset", () => {
+  it("clears malformed stored lists and returns empty values", () => {
+    window.localStorage.setItem("recent-captures", "{bad json");
+    const removeItemSpy = vi.spyOn(Storage.prototype, "removeItem");
+
+    const storedList = createStoredList("recent-captures", 5);
+
+    expect(storedList.load()).toEqual([]);
+    expect(removeItemSpy).toHaveBeenCalledWith("recent-captures");
+    expect(window.localStorage.getItem("recent-captures")).toBeNull();
+  });
+});

--- a/docs/src/storage.ts
+++ b/docs/src/storage.ts
@@ -137,18 +137,24 @@ export function loadMaxFileSizeMB(): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-export function saveMaxFileSizeMB(value: number | null): void {
+export function saveMaxFileSizeMB(value: number | null): boolean {
   const storage = getLocalStorage();
   if (!storage) {
-    return;
+    return false;
   }
 
-  if (value === null) {
-    storage.removeItem(MAX_FILE_SIZE_KEY);
-    return;
-  }
+  try {
+    if (value === null) {
+      storage.removeItem(MAX_FILE_SIZE_KEY);
+      return true;
+    }
 
-  storage.setItem(MAX_FILE_SIZE_KEY, String(value));
+    storage.setItem(MAX_FILE_SIZE_KEY, String(value));
+    return true;
+  } catch (err) {
+    console.warn("Failed to persist max file size preference", err);
+    return false;
+  }
 }
 
 export function loadFilterText(): string | null {
@@ -160,16 +166,22 @@ export function loadFilterText(): string | null {
   return storage.getItem(FILTER_TEXT_KEY);
 }
 
-export function saveFilterText(value: string | null): void {
+export function saveFilterText(value: string | null): boolean {
   const storage = getLocalStorage();
   if (!storage) {
-    return;
+    return false;
   }
 
-  if (value === null) {
-    storage.removeItem(FILTER_TEXT_KEY);
-    return;
-  }
+  try {
+    if (value === null) {
+      storage.removeItem(FILTER_TEXT_KEY);
+      return true;
+    }
 
-  storage.setItem(FILTER_TEXT_KEY, value);
+    storage.setItem(FILTER_TEXT_KEY, value);
+    return true;
+  } catch (err) {
+    console.warn("Failed to persist filter text preference", err);
+    return false;
+  }
 }


### PR DESCRIPTION
### Motivation
- Let the UI detect and non-blockingly surface when saving preferences to `localStorage` fails so users are informed without blocking normal operation. 
- Make preference persistence calls robust against unavailable storage and quota/write errors by handling exceptions at the API boundary. 

### Description
- Change `saveMaxFileSizeMB` and `saveFilterText` in `docs/src/storage.ts` to return a `boolean` success flag and wrap `setItem`/`removeItem` calls in `try/catch` with `console.warn` on error. 
- Add `preferencesPersistError` state to `docs/src/App.tsx` and update code paths that save preferences to set this flag when a save returns `false`. 
- Update the toolbar to show a non-blocking hint `Preferences not persisted.` when persistence fails, instead of the previous persistent-storage hint. 
- Add `docs/src/storage.test.tsx` tests for unavailable `localStorage`, quota/write failures (mocked `setItem` throwing), and malformed stored-list parse/reset; extend `docs/src/App.test.tsx` with a test that simulates a save failure and verifies the non-blocking hint. 

### Testing
- Ran the test suite with `cd docs && npm test`, which completed successfully. 
- All test files and assertions passed (`7` test files, `31` tests passed). 
- The new storage tests exercise mocked failures and produced expected warnings, and the new App test verifies the UI hint appears when persistence fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65bd6aac483289b9cf97f3a353cbe)