### PR TITLE
Fix GitHub Pages base path resolution for deployment

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -7,12 +7,19 @@ const repositoryName = repository?.includes("/")
   ? repository.split("/")[1]
   : undefined;
 
+const isUserOrOrgPagesRepository = repositoryName?.endsWith(".github.io");
+const basePath = repositoryName
+  ? isUserOrOrgPagesRepository
+    ? "/"
+    : `/${repositoryName}/`
+  : "/";
+
 type ViteWithVitestConfig = UserConfig & {
   test?: VitestUserConfig["test"];
 };
 
 const config: ViteWithVitestConfig = {
-  base: repositoryName ? `/${repositoryName}/` : "/",
+  base: basePath,
   plugins: [react()],
   test: {
     environment: "node",


### PR DESCRIPTION
## Summary
- update `docs/vite.config.ts` to derive `base` via a `basePath` helper
- keep project-page deployments on `/<repo>/`
- use `/` for user/org pages repositories ending in `.github.io`

## Why
GitHub Pages deployment can break when the repository is a user/org pages repo (`<account>.github.io`) because the previous config always forced `/<repo>/` when `GITHUB_REPOSITORY` was set. That causes built assets to resolve from the wrong path.

## Impact
- fixes asset loading for user/org pages deployments
- preserves existing behavior for project pages deployments

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65ed1ebf4832890aa6dcf87f1a65e)